### PR TITLE
improved insertNewPackageName

### DIFF
--- a/docs/JavaScript.md
+++ b/docs/JavaScript.md
@@ -212,6 +212,7 @@ Insert a new package inside the DB taking a `Server Object Full` as argument.
 
 ### database~insertNewPackageName(newName, oldName) ⇒ <code>object</code>
 Insert a new package name with the same pointer as the old name.
+This essentially renames an existing package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  

--- a/docs/complexity-report.md
+++ b/docs/complexity-report.md
@@ -9,7 +9,7 @@
 * Change cost: 13.580246913580247%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 19
 * Logical LOC: 11
@@ -19,7 +19,7 @@
 * Maintainability index: 63.4637930063897
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/config.js
 
 * Physical LOC: 102
 * Logical LOC: 40
@@ -49,7 +49,7 @@
     * Halstead volume: 2432.752928864466
     * Halstead effort: 77848.09372366291
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -69,7 +69,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -139,7 +139,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -189,7 +189,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -199,7 +199,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 142
 * Logical LOC: 7
@@ -209,7 +209,7 @@
 * Maintainability index: 69.95236801837311
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 120
 * Logical LOC: 79

--- a/src/database.js
+++ b/src/database.js
@@ -339,9 +339,7 @@ async function getPackageByName(name, user = false) {
         p.downloads, p.stargazers_count, p.original_stargazers, p.data,
         JSONB_AGG(JSON_BUILD_OBJECT(
           ${
-            user
-              ? sqlStorage``
-              : sqlStorage`'id', v.id, 'package', v.package,`
+            user ? sqlStorage`` : sqlStorage`'id', v.id, 'package', v.package,`
           } 'status', v.status, 'semver', v.semver,
           'license', v.license, 'engine', v.engine, 'meta', v.meta
         )) AS versions
@@ -1231,7 +1229,7 @@ async function simpleSearch(term, page, dir, sort) {
     sqlStorage ??= setupSQL();
 
     let limit = paginated_amount;
-    let offset = (page > 1) ? ((page - 1) * limit) : 0;
+    let offset = page > 1 ? (page - 1) * limit : 0;
 
     const command = await sqlStorage`
       SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
@@ -1309,7 +1307,7 @@ async function getSortedPackages(page, dir, method) {
   // only knowing we have a valid sort method provided.
 
   let limit = paginated_amount;
-  let offset = (page > 1) ? ((page - 1) * limit) : 0;
+  let offset = page > 1 ? (page - 1) * limit : 0;
 
   try {
     sqlStorage ??= setupSQL();

--- a/src/database.js
+++ b/src/database.js
@@ -1209,12 +1209,8 @@ async function simpleSearch(term, page, dir, sort) {
   try {
     sql_storage ??= setupSQL();
 
-    let offset = 0;
     let limit = paginated_amount;
-
-    if (page !== 1) {
-      offset = (page - 1) * paginated_amount;
-    }
+    let offset = (page > 1) ? ((page - 1) * limit) : 0;
 
     const command = await sql_storage`
       SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')

--- a/src/database.js
+++ b/src/database.js
@@ -1308,12 +1308,8 @@ async function getSortedPackages(page, dir, method) {
   // page, sort method, and direction. We must figure out the rest here.
   // only knowing we have a valid sort method provided.
 
-  let offset = 0;
   let limit = paginated_amount;
-
-  if (page !== 1) {
-    offset = (page - 1) * paginated_amount;
-  }
+  let offset = (page > 1) ? ((page - 1) * limit) : 0;
 
   try {
     sqlStorage ??= setupSQL();

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -50,10 +50,10 @@ async function getPackages(req, res) {
 
   packages = await utils.constructPackageObjectShort(packages.content);
 
-  let total_pages = await database.getTotalPackageEstimate();
+  let totalPages = await database.getTotalPackageEstimate();
 
-  if (!total_pages.ok) {
-    await common.handleError(req, res, total_pages, 1002);
+  if (!totalPages.ok) {
+    await common.handleError(req, res, totalPages, 1002);
     return;
   }
 
@@ -63,7 +63,7 @@ async function getPackages(req, res) {
       params.sort
     }&order=${
       params.direction
-    }>; rel="self", <${server_url}/api/packages?page=${total_pages}&sort=${
+    }>; rel="self", <${server_url}/api/packages?page=${totalPages}&sort=${
       params.sort
     }&order=${
       params.direction
@@ -148,31 +148,31 @@ async function postPackages(req, res) {
   }
 
   // Now knowing they own the git repo, and it doesn't exist here, lets publish.
-  let new_pack = await git.createPackage(params.repository, user.content);
+  let newPack = await git.createPackage(params.repository, user.content);
 
-  if (!new_pack.ok) {
-    await common.handleError(req, res, new_pack);
+  if (!newPack.ok) {
+    await common.handleError(req, res, newPack);
     return;
   }
 
   // Now with valid package data, we can insert them into the DB.
-  let inserted_new_pack = await database.insertNewPackage(new_pack.content);
+  let insertedNewPack = await database.insertNewPackage(newPack.content);
 
-  if (!inserted_new_pack.ok) {
-    await common.handleError(req, res, inserted_new_pack);
+  if (!insertedNewPack.ok) {
+    await common.handleError(req, res, insertedNewPack);
     return;
   }
 
   // Finally we can return what was actually put into the database.
   // Retrieve the data from database.getPackageByName() and
   // convert it into Package Object Full format.
-  let new_db_pack = await database.getPackageByName(repo, true);
+  let newDbPack = await database.getPackageByName(repo, true);
 
-  if (new_db_pack.ok) {
-    const package_object_full = await utils.constructPackageObjectFull(
-      new_db_pack.content
+  if (newDbPack.ok) {
+    const packageObjectFull = await utils.constructPackageObjectFull(
+      newDbPack.content
     );
-    res.status(201).json(package_object_full);
+    res.status(201).json(packageObjectFull);
   } else {
     common.serverError(req, res, "Cannot retrieve new package from DB");
   }
@@ -266,7 +266,7 @@ async function getPackagesSearch(req, res) {
 
   let totalPageEstimate = await database.getTotalPackageEstimate();
 
-  let total_pages = !totalPageEstimate.ok ? 1 : totalPageEstimate.content;
+  let totalPages = !totalPageEstimate.ok ? 1 : totalPageEstimate.content;
 
   // now to get headers.
   res.append(
@@ -277,7 +277,7 @@ async function getPackagesSearch(req, res) {
       params.direction
     }>; rel="self", <${server_url}/api/packages?q=${
       params.query
-    }&page=${total_pages}&sort=${params.sort}&order=${
+    }&page=${totalPages}&sort=${params.sort}&order=${
       params.direction
     }>; rel="last", <${server_url}/api/packages/search?q=${params.query}&page=${
       params.page + 1


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

I got errors about `express-rate-limit` module not found.

### Description of the Change

I gave a look at `insertNewPackageName`. I thought it may break uniqueness of `packages.name` inserting duplicate names into `names`. Only later I found out `names.name` is the primary key, so the new name should not be used to be inserted.

Anyway I added the code to update the name in the `packages` table (I suppose we want there the current name used, so the new name). And I wrapped the whole process into a transaction, which is useless if I made first the insertion in `names` and then exit on fail, but I wrongly supposed the names could be duplicated, so I made first the update into `packages`.

But the transaction is good anyway and also robust in case of unexpected errors, so I think it's acceptable as it is. Please give it a review.

Then I switched some variables to camel case notation.