### PR TITLE
Code refactoring

### DIFF
--- a/docs/complexity-report.md
+++ b/docs/complexity-report.md
@@ -9,7 +9,7 @@
 * Change cost: 13.580246913580247%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 19
 * Logical LOC: 11
@@ -19,7 +19,7 @@
 * Maintainability index: 63.4637930063897
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/config.js
 
 * Physical LOC: 102
 * Logical LOC: 40
@@ -49,7 +49,7 @@
     * Halstead volume: 2432.752928864466
     * Halstead effort: 77848.09372366291
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -69,7 +69,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -139,7 +139,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -189,7 +189,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -199,7 +199,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 142
 * Logical LOC: 7
@@ -209,7 +209,7 @@
 * Maintainability index: 69.95236801837311
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 120
 * Logical LOC: 79

--- a/src/database.js
+++ b/src/database.js
@@ -1204,44 +1204,20 @@ async function getSortedPackages(page, dir, method) {
   try {
     sqlStorage ??= setupSQL();
 
-    let command = null;
+    let orderType = null;
 
     switch (method) {
       case "downloads":
-        command = await sqlStorage`
-          SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
-          ORDER BY downloads
-          ${dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`}
-          LIMIT ${limit}
-          OFFSET ${offset};
-        `;
+        orderType = "downloads";
         break;
       case "created_at":
-        command = await sqlStorage`
-          SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
-          ORDER BY created
-          ${dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`}
-          LIMIT ${limit}
-          OFFSET ${offset};
-        `;
+        orderType = "created";
         break;
       case "updated_at":
-        command = await sqlStorage`
-          SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
-          ORDER BY updated
-          ${dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`}
-          LIMIT ${limit}
-          OFFSET ${offset};
-        `;
+        orderType = "updated";
         break;
       case "stars":
-        command = await sqlStorage`
-          SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
-          ORDER BY stargazers_count
-          ${dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`}
-          LIMIT ${limit}
-          OFFSET ${offset};
-        `;
+        orderType = "stargazers_count";
         break;
       default:
         logger.warningLog(
@@ -1255,6 +1231,14 @@ async function getSortedPackages(page, dir, method) {
           short: "Server Error",
         };
     }
+
+    const command = await sqlStorage`
+      SELECT * FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
+      ORDER BY ${orderType}
+      ${dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`}
+      LIMIT ${limit}
+      OFFSET ${offset};
+    `;
 
     return { ok: true, content: command };
   } catch (err) {


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Reduce duplication in `getSortedPackages`: use the switch to set only the order type.

Code refactoring in `removePackageByName`. Retrieve and save the pointer id rather selecting it in every query.

Doing this I had to deal with the missing package name. In this case, since we expect the package to be non-existent at the end of the execution, I thing having no pointer and count 0 is still `ok`, right? What do you think?

This lead me think about the count 0 on stars deletion. The package could have 0 stars, in this case the deletion will fail, but it shouldn't because there's nothing to delete. It's different than versions or names which at least 1 record has to be filled in the database.

Let me know if there's something wrong.

