### PR TITLE
Improve integrity on package versions

### DIFF
--- a/docs/JavaScript.md
+++ b/docs/JavaScript.md
@@ -372,7 +372,8 @@ Given a package name, removes its record alongside its names, versions, stars.
 
 ### database~removePackageVersion(packName, semVer) ⇒ <code>object</code>
 Mark a version of a specific package as removed. This does not delete the record,
-just mark the status as removed.
+just mark the status as removed, but only if one published version remain available.
+This also makes sure that a new latest version is selected in case the previous one is removed.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -1077,7 +1078,11 @@ A helper for any functions that are agnostic in handlers.
     * [~constructPackageObjectShort(pack)](#module_utils..constructPackageObjectShort) ⇒ <code>object</code>
     * [~constructPackageObjectJSON(pack)](#module_utils..constructPackageObjectJSON) ⇒ <code>object</code>
     * [~deepCopy(obj)](#module_utils..deepCopy) ⇒ <code>object</code>
-    * [~engineFilter()](#module_utils..engineFilter)
+    * [~engineFilter()](#module_utils..engineFilter) ⇒ <code>object</code>
+    * [~semverArray(semver)](#module_utils..semverArray) ⇒ <code>array</code>
+    * [~semverGt(a1, a2)](#module_utils..semverGt) ⇒ <code>boolean</code>
+    * [~semverLt(a1, a2)](#module_utils..semverLt) ⇒ <code>boolean</code>
+    * [~semverEq(a1, a2)](#module_utils..semverEq) ⇒ <code>boolean</code>
 
 <a name="module_utils..StateStore"></a>
 
@@ -1176,12 +1181,70 @@ Just in case it is needed again.
 
 <a name="module_utils..engineFilter"></a>
 
-### utils~engineFilter()
+### utils~engineFilter() ⇒ <code>object</code>
 A complex function that provides filtering by Atom engine version.
 This should take a package with it's versions and retreive whatever matches
 that engine version as provided.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
+**Returns**: <code>object</code> - The filtered object.  
+<a name="module_utils..semverArray"></a>
+
+### utils~semverArray(semver) ⇒ <code>array</code>
+Takes a semver string and return it as an Array of strings
+
+**Kind**: inner method of [<code>utils</code>](#module_utils)  
+**Returns**: <code>array</code> - Formatted semver  
+
+| Param | Type |
+| --- | --- |
+| semver | <code>string</code> | 
+
+<a name="module_utils..semverGt"></a>
+
+### utils~semverGt(a1, a2) ⇒ <code>boolean</code>
+Compares two sermver and return true if the first is greater than the second.
+Expects to get the semver formatted as array of strings.
+Should be always executed after running semverArray.
+
+**Kind**: inner method of [<code>utils</code>](#module_utils)  
+**Returns**: <code>boolean</code> - The result of the comparison  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| a1 | <code>array</code> | First semver as array |
+| a2 | <code>array</code> | Second semver as array |
+
+<a name="module_utils..semverLt"></a>
+
+### utils~semverLt(a1, a2) ⇒ <code>boolean</code>
+Compares two sermver and return true if the first is less than the second.
+Expects to get the semver formatted as array of strings.
+Should be always executed after running semverArray.
+
+**Kind**: inner method of [<code>utils</code>](#module_utils)  
+**Returns**: <code>boolean</code> - The result of the comparison  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| a1 | <code>array</code> | First semver as array |
+| a2 | <code>array</code> | Second semver as array |
+
+<a name="module_utils..semverEq"></a>
+
+### utils~semverEq(a1, a2) ⇒ <code>boolean</code>
+Compares two sermver and return true if the first is equal to the second.
+Expects to get the semver formatted as array of strings.
+Should be always executed after running semverArray.
+
+**Kind**: inner method of [<code>utils</code>](#module_utils)  
+**Returns**: <code>boolean</code> - The result of the comparison  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| a1 | <code>array</code> | First semver as array |
+| a2 | <code>array</code> | Second semver as array |
+
 <a name="module_common_handler"></a>
 
 ## common\_handler

--- a/docs/complexity-report.md
+++ b/docs/complexity-report.md
@@ -1,4 +1,4 @@
-# Complexity report, 11/25/2022
+# Complexity report, 11/26/2022
 
 * Mean per-function logical LOC: 19.666666666666668
 * Mean per-function parameter count: 0.5277777777777778
@@ -9,7 +9,7 @@
 * Change cost: 13.580246913580247%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 19
 * Logical LOC: 11
@@ -19,7 +19,7 @@
 * Maintainability index: 63.4637930063897
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/config.js
 
 * Physical LOC: 102
 * Logical LOC: 40
@@ -49,7 +49,7 @@
     * Halstead volume: 2432.752928864466
     * Halstead effort: 77848.09372366291
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -69,7 +69,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -139,7 +139,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -189,7 +189,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -199,7 +199,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 142
 * Logical LOC: 7
@@ -209,7 +209,7 @@
 * Maintainability index: 69.95236801837311
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 120
 * Logical LOC: 79

--- a/src/database.js
+++ b/src/database.js
@@ -7,6 +7,7 @@
 const fs = require("fs");
 const postgres = require("postgres");
 const storage = require("./storage.js");
+const utils = require("./utils.js");
 const logger = require("./logger.js");
 const {
   DB_HOST,
@@ -704,39 +705,154 @@ async function removePackageByName(name) {
  * @async
  * @function removePackageVersion
  * @description Mark a version of a specific package as removed. This does not delete the record,
- * just mark the status as removed.
+ * just mark the status as removed, but only if one published version remain available.
+ * This also makes sure that a new latest version is selected in case the previous one is removed.
  * @param {string} packName - The package name.
  * @param {string} semVer - The version to remove.
  * @returns {object} A server status object.
  */
 async function removePackageVersion(packName, semVer) {
-  try {
-    sqlStorage ??= setupSQL();
+  sqlStorage ??= setupSQL();
 
-    const command = await sqlStorage`
-       UPDATE versions
-       SET status = 'removed'
-       WHERE semver = ${semVer} AND package IN (
-         SELECT pointer
-         FROM names
-         WHERE name = ${packName}
-       )
-       RETURNING *;
-     `;
+  return await sqlStorage
+    .begin(async () => {
+      // Retrieve the package pointer
+      const getID = await sqlStorage`
+        SELECT pointer
+        FROM names
+        WHERE name = ${packName};
+      `;
 
-    return command.count !== 0
-      ? {
-          ok: true,
-          content: `Successfully removed ${semVer} version of ${packName} package.`,
+      if (getID.count === 0) {
+        throw `Unable to find the pointer of ${packName}`;
+      }
+
+      const pointer = getID[0].pointer;
+
+      // Retrieve all non-removed versions
+      const getVersions = await sqlStorage`
+        SELECT id, semver, status
+        FROM versions
+        WHERE package = ${pointer} AND status != 'removed';
+      `;
+
+      const versionCount = getVersions.count;
+      if (versionCount === 0) {
+        throw `No published version available for ${packName} package`;
+      }
+
+      // Having all versions, we loop them to find:
+      // - the id of the version to remove
+      // - if its status is "latest"
+      let removeLatest = false;
+      let versionId = null;
+      for (const v of getVersions) {
+        if (v.semver === semVer) {
+          versionId = v.id;
+          removeLatest = (v.status === "latest");
         }
-      : {
+      }
+
+      if (versionId === null) {
+        // Do not use throw here because we specify Not Found reason.
+        return {
+          ok: false,
+          content: `There's no version ${semVer} to remove for ${packName} package`,
+          short: "Not Found",
+        }
+      }
+
+      // We have the version to remove, but for the package integrity we have to make sure that
+      // at least one published version is still available after the removal.
+      // This is not possible if the version count is only 1.
+      if (versionCount === 1) {
+        throw `It'n not possible to leave the ${packName} without at least one published version`;
+      }
+
+      // The package will have published versions, so we can remove the targeted semver.
+      const command = await sqlStorage`
+        UPDATE versions
+        SET status = 'removed'
+        WHERE id = ${versionId}
+        RETURNING *;
+      `;
+
+      if (command.count === 0) {
+        // Do not use throw here because we specify Not Found reason.
+        return {
           ok: false,
           content: `Unable to remove ${semVer} version of ${packName} package.`,
           short: "Not Found",
         };
-  } catch (err) {
-    return { ok: false, content: err, short: "Server Error" };
-  }
+      }
+
+      if (!removeLatest) {
+        // We have removed a published versions and the latest one is still available.
+        return {
+          ok: true,
+          content: `Successfully removed ${semVer} version of ${packName} package.`,
+        };
+      }
+
+      // We have removed the version with the "latest" status, so now we have to select
+      // a new version between the remaining ones which will obtain "latest" status.
+      // We use the utils in utils.js to select the highest semver.
+      let highestVersionId = null;
+      let latestSemver = null;
+      let maxSemVer = null;
+      for (const v of getVersions) {
+        if (v.id === versionId) {
+          // Skip the removed version
+          continue;
+        }
+
+        if (maxSemVer === null) {
+          // Initialize variables
+          latestSemver = v.semver;
+          maxSemVer = utils.semverArray(latestSemver);
+          highestVersionId = v.id;
+          continue;
+        }
+
+        const sva = utils.semverArray()
+        if (utils.semverGt(sva, maxSemVer)) {
+          latestSemver = v.semver;
+          maxSemVer = utils.semverArray(latestSemver);
+          highestVersionId = v.id;
+        }
+      }
+
+      if (highestVersionId === null) {
+        throw `An error occurred while selecting the highest versions of ${packName}`;
+      }
+
+      // Mark the targeted highest version as latest.
+      const commandLatest = await sqlStorage`
+        UPDATE versions
+        SET status = 'latest'
+        WHERE id = ${highestVersionId}
+        RETURNING *;
+      `;
+
+      return commandLatest.count !== 0
+        ? {
+            ok: true,
+            content: `Removed ${semVer} of ${packName} and ${latestSemver} is the new latest version.`,
+          }
+        : {
+            ok: false,
+            content: `Unable to remove ${semVer} version of ${packName} package.`,
+            short: "Not Found",
+          };
+    })
+    .catch((err) => {
+      const msg =
+        typeof err === "string"
+          ? err
+          : `A generic error occurred while inserting ${pack.name} package`;
+
+      return { ok: false, content: msg, short: "Server Error" };
+    });
 }
 
 /**

--- a/src/database.js
+++ b/src/database.js
@@ -749,7 +749,7 @@ async function removePackageVersion(packName, semVer) {
       for (const v of getVersions) {
         if (v.semver === semVer) {
           versionId = v.id;
-          removeLatest = (v.status === "latest");
+          removeLatest = v.status === "latest";
         }
       }
 
@@ -759,7 +759,7 @@ async function removePackageVersion(packName, semVer) {
           ok: false,
           content: `There's no version ${semVer} to remove for ${packName} package`,
           short: "Not Found",
-        }
+        };
       }
 
       // We have the version to remove, but for the package integrity we have to make sure that
@@ -814,7 +814,7 @@ async function removePackageVersion(packName, semVer) {
           continue;
         }
 
-        const sva = utils.semverArray()
+        const sva = utils.semverArray();
         if (utils.semverGt(sva, maxSemVer)) {
           latestSemver = v.semver;
           maxSemVer = utils.semverArray(latestSemver);

--- a/src/utils.js
+++ b/src/utils.js
@@ -206,59 +206,14 @@ async function deepCopy(obj) {
 }
 
 /**
+ * @async
  * @function engineFilter
  * @desc A complex function that provides filtering by Atom engine version.
  * This should take a package with it's versions and retreive whatever matches
  * that engine version as provided.
+ * @returns {object} The filtered object.
  */
 async function engineFilter(pack, engine) {
-  // Comparison utils:
-  // These ones expect to get valid strings as parameters, which should be convertible to numbers.
-  // Providing other types may lead to unexpected behaviors.
-  // Always to be executed after passing the semver format validity.
-  const gt = (a1, a2) => {
-    const v1 = a1.map((n) => parseInt(n, 10));
-    const v2 = a2.map((n) => parseInt(n, 10));
-
-    if (v1[0] > v2[0]) {
-      return true;
-    } else if (v1[0] < v2[0]) {
-      return false;
-    }
-
-    if (v1[1] > v2[1]) {
-      return true;
-    } else if (v1[1] < v2[1]) {
-      return false;
-    }
-
-    return v1[2] > v2[2];
-  };
-
-  const lt = (a1, a2) => {
-    const v1 = a1.map((n) => parseInt(n, 10));
-    const v2 = a2.map((n) => parseInt(n, 10));
-
-    if (v1[0] < v2[0]) {
-      return true;
-    } else if (v1[0] > v2[0]) {
-      return false;
-    }
-
-    if (v1[1] < v2[1]) {
-      return true;
-    } else if (v1[1] > v2[1]) {
-      return false;
-    }
-
-    return v1[2] < v2[2];
-  };
-
-  const eq = (a1, a2) => {
-    return a1[0] === a2[0] && a1[1] === a2[1] && a1[2] === a2[2];
-  };
-
-  // Function start.
   // If a compatible version is found, we add its data to the metadata property of the package
   // Otherwise we return an unmodified package, so that it is usable to the consumer.
 
@@ -267,7 +222,7 @@ async function engineFilter(pack, engine) {
     return pack;
   }
 
-  const eng_sv = engine.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
+  const eng_sv = semverArray(engine);
 
   // Validate engine semver format.
   if (eng_sv === null) {
@@ -302,7 +257,7 @@ async function engineFilter(pack, engine) {
       // Lower end condition present, so test it.
       switch (low_sv[1]) {
         case ">":
-          lower_end = gt(
+          lower_end = semverGt(
             [eng_sv[1], eng_sv[2], eng_sv[3]],
             [low_sv[2], low_sv[3], low_sv[4]]
           );
@@ -310,11 +265,11 @@ async function engineFilter(pack, engine) {
           break;
         case ">=":
           lower_end =
-            gt(
+            semverGt(
               [eng_sv[1], eng_sv[2], eng_sv[3]],
               [low_sv[2], low_sv[3], low_sv[4]]
             ) ||
-            eq(
+            semverEq(
               [eng_sv[1], eng_sv[2], eng_sv[3]],
               [low_sv[2], low_sv[3], low_sv[4]]
             );
@@ -332,7 +287,7 @@ async function engineFilter(pack, engine) {
       // Upper end condition present, so test it.
       switch (up_sv[1]) {
         case "<":
-          upper_end = lt(
+          upper_end = semverLt(
             [eng_sv[1], eng_sv[2], eng_sv[3]],
             [up_sv[2], up_sv[3], up_sv[4]]
           );
@@ -340,11 +295,11 @@ async function engineFilter(pack, engine) {
           break;
         case "<=":
           upper_end =
-            lt(
+            semverLt(
               [eng_sv[1], eng_sv[2], eng_sv[3]],
               [up_sv[2], up_sv[3], up_sv[4]]
             ) ||
-            eq(
+            semverEq(
               [eng_sv[1], eng_sv[2], eng_sv[3]],
               [up_sv[2], up_sv[3], up_sv[4]]
             );
@@ -362,7 +317,7 @@ async function engineFilter(pack, engine) {
 
       if (
         eq_sv !== null &&
-        eq([eng_sv[1], eng_sv[2], eng_sv[3]], [eq_sv[1], eq_sv[2], eq_sv[3]])
+        semverEq([eng_sv[1], eng_sv[2], eng_sv[3]], [eq_sv[1], eq_sv[2], eq_sv[3]])
       ) {
         compatible_version = ver;
 
@@ -408,6 +363,85 @@ async function engineFilter(pack, engine) {
   pack.metadata = pack.versions[compatible_version];
 
   return pack;
+}
+
+/**
+ * @function semverArray
+ * @desc Takes a semver string and return it as an Array of strings
+ * @param {string} semver
+ * @returns {array} Formatted semver
+ */
+function semverArray(semver) {
+  return semver.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
+}
+
+/**
+ * @function semverGt
+ * @desc Compares two sermver and return true if the first is greater than the second.
+ * Expects to get the semver formatted as array of strings.
+ * Should be always executed after running semverArray.
+ * @param {array} a1 - First semver as array
+ * @param {array} a2 - Second semver as array
+ * @returns {boolean} The result of the comparison
+ */
+function semverGt(a1, a2) {
+  const v1 = a1.map((n) => parseInt(n, 10));
+  const v2 = a2.map((n) => parseInt(n, 10));
+
+  if (v1[0] > v2[0]) {
+    return true;
+  } else if (v1[0] < v2[0]) {
+    return false;
+  }
+
+  if (v1[1] > v2[1]) {
+    return true;
+  } else if (v1[1] < v2[1]) {
+    return false;
+  }
+
+  return v1[2] > v2[2];
+}
+
+/**
+ * @function semverLt
+ * @desc Compares two sermver and return true if the first is less than the second.
+ * Expects to get the semver formatted as array of strings.
+ * Should be always executed after running semverArray.
+ * @param {array} a1 - First semver as array
+ * @param {array} a2 - Second semver as array
+ * @returns {boolean} The result of the comparison
+ */
+function semverLt(a1, a2) {
+  const v1 = a1.map((n) => parseInt(n, 10));
+  const v2 = a2.map((n) => parseInt(n, 10));
+
+  if (v1[0] < v2[0]) {
+    return true;
+  } else if (v1[0] > v2[0]) {
+    return false;
+  }
+
+  if (v1[1] < v2[1]) {
+    return true;
+  } else if (v1[1] > v2[1]) {
+    return false;
+  }
+
+  return v1[2] < v2[2];
+}
+
+/**
+ * @function semverEq
+ * @desc Compares two sermver and return true if the first is equal to the second.
+ * Expects to get the semver formatted as array of strings.
+ * Should be always executed after running semverArray.
+ * @param {array} a1 - First semver as array
+ * @param {array} a2 - Second semver as array
+ * @returns {boolean} The result of the comparison
+ */
+function semverEq(a1, a2) {
+  return a1[0] === a2[0] && a1[1] === a2[1] && a1[2] === a2[2];
 }
 
 /**
@@ -458,5 +492,9 @@ module.exports = {
   constructPackageObjectJSON,
   deepCopy,
   engineFilter,
+  semverArray,
+  semverGt,
+  semverLt,
+  semverEq,
   StateStore,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -317,7 +317,10 @@ async function engineFilter(pack, engine) {
 
       if (
         eq_sv !== null &&
-        semverEq([eng_sv[1], eng_sv[2], eng_sv[3]], [eq_sv[1], eq_sv[2], eq_sv[3]])
+        semverEq(
+          [eng_sv[1], eng_sv[2], eng_sv[3]],
+          [eq_sv[1], eq_sv[2], eq_sv[3]]
+        )
       ) {
         compatible_version = ver;
 


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

So I was thinking about [this](https://github.com/confused-Techie/atom-backend/issues/61#issuecomment-1327916394) and came up with a possible solution. 

When we remove a package, we make sure:
- at least one published/latest version remains;
- if the latest published version is removed, another one is selected between the published available.

The hardest part is when the latest version is removed. I thought to pick the highest semver, but to do this I had to expose the utils we used in `utils.js`.

So I extracted them and made them as modules. Then attached `utils.js` as dependency of `database.js` 

`removePackageVersion` has been rewritten as transactional:
1.  get the package pointer
2. get all non-removed the versions
3. get the id of the version to remove
4. rollback if no published versions remains after the removal
5. remove the version and commit if it was published
6. continue if it was the latest and pick the highest version
7. mark the highest as latest and commit

@confused-Techie what do you think? Please, check it out.