### PR TITLE
Code refactoring

### DIFF
--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -596,6 +596,7 @@ Assists in interactions between the backend and GitHub.
     * [~setGHAPIURL(val)](#module_git..setGHAPIURL)
     * [~ownership(user, repo, [dev_override])](#module_git..ownership)
     * [~createPackage(repo)](#module_git..createPackage) ⇒ <code>object</code>
+    * [~selectPackageRepository(repo)](#module_git..selectPackageRepository) ⇒ <code>object</code>
     * [~doesUserHaveRepo(user, repo, [page])](#module_git..doesUserHaveRepo) ⇒ <code>object</code>
     * [~getRepoExistance(repo)](#module_git..getRepoExistance) ⇒ <code>boolean</code>
     * [~getPackageJSON(repo)](#module_git..getPackageJSON) ⇒ <code>string</code> \| <code>undefined</code>
@@ -656,6 +657,19 @@ return back a proper `Server Object Full` object within a `Server Status`.conten
 | Param | Type | Description |
 | --- | --- | --- |
 | repo | <code>string</code> | The Repo to use in the form `owner/repo`. |
+
+<a name="module_git..selectPackageRepository"></a>
+
+### git~selectPackageRepository(repo) ⇒ <code>object</code>
+Determines the repository object by the given argument.
+The functionality will only be declarative for now, and may change later on.
+
+**Kind**: inner method of [<code>git</code>](#module_git)  
+**Returns**: <code>object</code> - The object related to the package repository type.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| repo | <code>string</code> \| <code>object</code> | The repository of the retrieved package. |
 
 <a name="module_git..doesUserHaveRepo"></a>
 
@@ -866,7 +880,7 @@ engine(): Returns false if not defined, to allow a fast way to determine if resu
     * [~sort(req, [def])](#module_query..sort) ⇒ <code>string</code>
     * [~dir(req)](#module_query..dir) ⇒ <code>string</code>
     * [~query(req)](#module_query..query) ⇒ <code>string</code>
-    * [~engine(req)](#module_query..engine) ⇒ <code>string</code> \| <code>boolean</code>
+    * [~engine(semver)](#module_query..engine) ⇒ <code>string</code> \| <code>boolean</code>
     * [~auth(req)](#module_query..auth) ⇒ <code>string</code>
     * [~repo(req)](#module_query..repo) ⇒ <code>string</code>
     * [~tag(req)](#module_query..tag) ⇒ <code>string</code>
@@ -929,7 +943,7 @@ it is not a malicious request. Returning "" if an unsafe or invalid query is pas
 
 <a name="module_query..engine"></a>
 
-### query~engine(req) ⇒ <code>string</code> \| <code>boolean</code>
+### query~engine(semver) ⇒ <code>string</code> \| <code>boolean</code>
 Parses the 'engine' query parameter to ensure its valid, otherwise returning false.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
@@ -937,7 +951,7 @@ Parses the 'engine' query parameter to ensure its valid, otherwise returning fal
 
 | Param | Type | Description |
 | --- | --- | --- |
-| req | <code>object</code> \| <code>string</code> | The `Request` object inherited from the Express endpoint or the engine string. |
+| semver | <code>string</code> | The engine string. |
 
 <a name="module_query..auth"></a>
 
@@ -1093,7 +1107,7 @@ A helper for any functions that are agnostic in handlers.
     * [~constructPackageObjectJSON(pack)](#module_utils..constructPackageObjectJSON) ⇒ <code>object</code>
     * [~deepCopy(obj)](#module_utils..deepCopy) ⇒ <code>object</code>
     * [~engineFilter()](#module_utils..engineFilter) ⇒ <code>object</code>
-    * [~semverArray(semver)](#module_utils..semverArray) ⇒ <code>array</code>
+    * [~semverArray(semver)](#module_utils..semverArray) ⇒ <code>array</code> \| <code>null</code>
     * [~semverGt(a1, a2)](#module_utils..semverGt) ⇒ <code>boolean</code>
     * [~semverLt(a1, a2)](#module_utils..semverLt) ⇒ <code>boolean</code>
     * [~semverEq(a1, a2)](#module_utils..semverEq) ⇒ <code>boolean</code>
@@ -1204,11 +1218,11 @@ that engine version as provided.
 **Returns**: <code>object</code> - The filtered object.  
 <a name="module_utils..semverArray"></a>
 
-### utils~semverArray(semver) ⇒ <code>array</code>
+### utils~semverArray(semver) ⇒ <code>array</code> \| <code>null</code>
 Takes a semver string and return it as an Array of strings
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
-**Returns**: <code>array</code> - Formatted semver  
+**Returns**: <code>array</code> \| <code>null</code> - The formatted semver in array of three strings, or null if no match.  
 
 | Param | Type |
 | --- | --- |

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -1,15 +1,15 @@
 # Complexity report, 12/3/2022
 
-* Mean per-function logical LOC: 19.4
+* Mean per-function logical LOC: 18.8
 * Mean per-function parameter count: 0.475
 * Mean per-function cyclomatic complexity: 3.75
-* Mean per-function Halstead effort: 13750.865985361976
-* Mean per-module maintainability index: 61.32552361151022
+* Mean per-function Halstead effort: 13447.410616752832
+* Mean per-module maintainability index: 61.420130684311985
 * First-order density: 2%
 * Change cost: 12%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 19
 * Logical LOC: 11
@@ -19,7 +19,7 @@
 * Maintainability index: 63.4637930063897
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/config.js
 
 * Physical LOC: 102
 * Logical LOC: 40
@@ -49,7 +49,7 @@
     * Halstead volume: 2432.752928864466
     * Halstead effort: 77848.09372366291
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -69,7 +69,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -139,7 +139,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -189,7 +189,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -199,7 +199,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 142
 * Logical LOC: 7
@@ -209,17 +209,17 @@
 * Maintainability index: 69.95236801837311
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
-* Physical LOC: 121
-* Logical LOC: 77
+* Physical LOC: 123
+* Logical LOC: 71
 * Mean parameter count: 0
 * Cyclomatic complexity: 1
-* Cyclomatic complexity density: 1.2987012987012987%
-* Maintainability index: 37.88070189316366
+* Cyclomatic complexity density: 1.4084507042253522%
+* Maintainability index: 38.82677262118128
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
 
 * Physical LOC: 25
 * Logical LOC: 19

--- a/src/database.js
+++ b/src/database.js
@@ -379,8 +379,8 @@ async function getPackageByName(name, user = false) {
           'license', v.license, 'engine', v.engine, 'meta', v.meta
         )) AS versions
       FROM packages p
-        JOIN versions v ON p.pointer = v.package
-        JOIN names n ON n.pointer = p.pointer
+        JOIN versions v ON (p.pointer = v.package) AND (v.status != 'removed')
+        JOIN names n ON (n.pointer = p.pointer)
       WHERE n.name = ${name}
       GROUP BY p.pointer, v.package;
     `;
@@ -417,7 +417,7 @@ async function getPackageVersionByNameAndVersion(name, version) {
         FROM names
         WHERE name = ${name}
       )
-      AND semver = ${version};
+      AND semver = ${version} AND status != 'removed';
     `;
 
     return command.count !== 0

--- a/src/git.js
+++ b/src/git.js
@@ -242,6 +242,7 @@ async function createPackage(repo, user) {
       };
     }
 
+    const semVerInitRegex = /^\s?v/i;
     let versionCount = 0;
     newPack.versions = {};
 
@@ -256,7 +257,7 @@ async function createPackage(repo, user) {
         }
 
         for (const tag of repoTag) {
-          const shortTag = query.engine(tag.name.replace(/^\s?v/i, ""));
+          const shortTag = query.engine(tag.name.replace(semVerInitRegex, ""));
           if (ver === shortTag) {
             // they match tag and version, stuff the data into the package.
             newPack.versions[ver] = pack;
@@ -282,7 +283,7 @@ async function createPackage(repo, user) {
         // will allow modifications.
         // But now we do need to retreive, the tarball data.
         for (const tag of repoTag) {
-          const shortTag = query.engine(tag.name.replace(/^\s?v/i, ""));
+          const shortTag = query.engine(tag.name.replace(semVerInitRegex, ""));
           if (ver === shortTag) {
             newPack.versions[ver] = pack;
             newPack.versions[ver].tarball_url = tag.tarball_url;
@@ -304,7 +305,7 @@ async function createPackage(repo, user) {
 
     // now with all the versions properly filled, we lastly just need the release data.
     newPack.releases = {
-      latest: repoTag[0].name.replace(/^\s?v/i, ""),
+      latest: repoTag[0].name.replace(semVerInitRegex, ""),
     };
 
     // for this we just use the most recent tag published to the repo.

--- a/src/git.js
+++ b/src/git.js
@@ -7,6 +7,7 @@ const superagent = require("superagent");
 const { GH_USERAGENT } = require("./config.js").getConfig();
 const logger = require("./logger.js");
 const query = require("./query.js");
+const utils = require("./utils.js");
 let GH_API_URL = "https://api.github.com";
 let GH_WEB_URL = "https://github.com";
 
@@ -171,7 +172,21 @@ async function createPackage(repo, user) {
       };
     }
 
-    // now to get our readme
+    // Build a repo tag object indexed by tag names so we can handle versions easily and
+    // won't call query.engine() multiple times for a single version.
+    const semVerInitRegex = /^\s*v/i;
+    let tagList = {};
+    for (const tag of repoTag) {
+      if (typeof tag.name !== "string") {
+        continue;
+      }
+      const sv = query.engine(tag.name.replace(semVerInitRegex, "").trim());
+      if (sv !== false) {
+        tagList[sv] = tag;
+      }
+    }
+
+    // Now to get our readme
     let readme = await getRepoReadMe(repo, user);
 
     if (readme === undefined) {
@@ -207,91 +222,63 @@ async function createPackage(repo, user) {
     newPack.readme = readme;
     newPack.metadata = pack; // The metadata tag is the most recent package.json file, in full.
 
-    // currently there is no purpose to store the type of repo. But for the time being,
+    // Currently there is no purpose to store the type of repo. But for the time being,
     // we will assume this could be used in the future as a way to determine how to interact with a repo.
-    // The functionality will only be declarative for now, and may change later on.
-    // Although first party packages do already have the regular package object. So we
-    // will need to check if its an object or string.
-    if (typeof pack.repository !== "string") {
-      newPack.repository = pack.repository; // likely a first party package, with an
-      // already valid package object, that can just be added over.
-    } else if (pack.repository.includes("github")) {
-      newPack.repository = {
-        type: "git",
-        url: pack.repository,
-      };
-    } else if (pack.repository.includes("bitbucket")) {
-      newPack.repository = {
-        type: "bit",
-        url: pack.repository,
-      };
-    } else if (pack.repository.includes("sourceforge")) {
-      newPack.repository = {
-        type: "sfr",
-        url: pack.repository,
-      };
-    } else if (pack.repository.includes("gitlab")) {
-      newPack.repository = {
-        type: "lab",
-        url: pack.repository,
-      };
-    } else {
-      newPack.repository = {
-        type: "na",
-        url: pack.repository,
-      };
-    }
+    newPack.repository = selectPackageRepository(pack.repository);
 
-    const semVerInitRegex = /^\s?v/i;
-    let versionCount = 0;
-    newPack.versions = {};
-
-    // now during migration packages will have a 'versions' key, but otherwise the standard
-    // package will just have a 'version', so we will check which is present.
+    // Now during migration packages will have a 'versions' key, but otherwise the standard
+    // package will just have a 'version'.
+    // We build the array of available versions extracted from the pack object.
+    let versionList = [];
     if (pack.versions) {
-      // now to add the release data to each release within the package
       for (const v of Object.keys(pack.versions)) {
-        const ver = query.engine(v);
-        if (ver === false) {
-          continue;
-        }
-
-        for (const tag of repoTag) {
-          const shortTag = query.engine(tag.name.replace(semVerInitRegex, ""));
-          if (ver === shortTag) {
-            // they match tag and version, stuff the data into the package.
-            newPack.versions[ver] = pack;
-            // TODO::
-            // Its worthy to note that ^^^ assigns the current package.json file within the repo
-            // as the version tag. Now this in most cases during a publish should be fine.
-            // But if a user were to publish a version to the backend AFTER having published several
-            // versions to their repo, this would cause identical versions to be created, although
-            // would have the correct download URL. So the error would only be visual when browsing
-            // the packages details.
-            newPack.versions[ver].tarball_url = tag.tarball_url;
-            newPack.versions[ver].sha = tag.commit.sha;
-            versionCount++;
-            break;
-          }
-        }
+        versionList.push(v);
       }
     } else if (pack.version) {
-      const ver = query.engine(pack.version);
-      if (ver !== false) {
-        // Otherwise if they only have a version tag, we can make the first entry onto the versions.
-        // This first entry of course, contains the package.json currently, and in the future,
-        // will allow modifications.
-        // But now we do need to retreive, the tarball data.
-        for (const tag of repoTag) {
-          const shortTag = query.engine(tag.name.replace(semVerInitRegex, ""));
-          if (ver === shortTag) {
-            newPack.versions[ver] = pack;
-            newPack.versions[ver].tarball_url = tag.tarball_url;
-            newPack.versions[ver].sha = tag.commit.sha;
-            versionCount++;
-            break;
-          }
-        }
+      versionList.push(pack.version);
+    }
+
+    let versionCount = 0;
+    let latestVersion = null;
+    let latestSemverArr = null;
+    newPack.versions = {};
+    // Now to add the release data to each release within the package
+    for (const v of versionList) {
+      const ver = query.engine(v);
+      if (ver === false) {
+        continue;
+      }
+
+      const tag = tagList[ver];
+      if (tag === undefined) {
+        continue;
+      }
+
+      // They match tag and version, stuff the data into the package.
+      newPack.versions[ver] = pack;
+      // TODO::
+      // Its worthy to note that ^^^ assigns the current package.json file within the repo
+      // as the version tag. Now this in most cases during a publish should be fine.
+      // But if a user were to publish a version to the backend AFTER having published several
+      // versions to their repo, this would cause identical versions to be created, although
+      // would have the correct download URL. So the error would only be visual when browsing
+      // the packages details.
+      newPack.versions[ver].tarball_url = tag.tarball_url;
+      newPack.versions[ver].sha = tag.commit.sha;
+      versionCount++;
+
+      // Check latest version.
+      if (latestVersion === null) {
+        // Initialize latestVersion
+        latestVersion = ver;
+        latestSemverArr = utils.semverArray(ver);
+        continue;
+      }
+
+      const sva = utils.semverArray(ver);
+      if (utils.semverGt(sva, latestSemverArr)) {
+        latestVersion = ver;
+        latestSemverArr = sva;
       }
     }
 
@@ -303,9 +290,9 @@ async function createPackage(repo, user) {
       };
     }
 
-    // now with all the versions properly filled, we lastly just need the release data.
+    // Now with all the versions properly filled, we lastly just need the release data.
     newPack.releases = {
-      latest: repoTag[0].name.replace(semVerInitRegex, ""),
+      latest: latestVersion,
     };
 
     // for this we just use the most recent tag published to the repo.
@@ -314,6 +301,69 @@ async function createPackage(repo, user) {
   } catch (err) {
     // an error occured somewhere during package generation
     return { ok: false, content: err, short: "Server Error" };
+  }
+}
+
+/**
+ * @function selectPackageRepository
+ * @desc Determines the repository object by the given argument.
+ * The functionality will only be declarative for now, and may change later on.
+ * @param {string|object} repo - The repository of the retrieved package.
+ * @returns {object} The object related to the package repository type.
+ */
+function selectPackageRepository(repo) {
+  try {
+    // First party packages do already have the regular package object.
+    // So we will need to check if its an object or string.
+
+    if (!repo) {
+      // In case of faulty value, just return and empty url.
+      return {
+        type: "na",
+        url: "",
+      };
+    }
+
+    if (typeof repo !== "string") {
+      // Likely a first party package, with an already valid package object,
+      // that can just be added over.
+      return repo;
+    }
+
+    if (repo.includes("github")) {
+      return {
+        type: "git",
+        url: repo,
+      };
+    }
+    if (repo.includes("bitbucket")) {
+      return {
+        type: "bit",
+        url: repo,
+      };
+    }
+    if (repo.includes("sourceforge")) {
+      return {
+        type: "sfr",
+        url: repo,
+      };
+    }
+    if (repo.includes("gitlab")) {
+      return {
+        type: "lab",
+        url: repo,
+      };
+    }
+
+    return {
+      type: "na",
+      url: repo,
+    };
+  } catch (e) {
+    return {
+      type: "na",
+      url: "",
+    };
   }
 }
 

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -301,7 +301,7 @@ async function getPackagesSearch(req, res) {
  */
 async function getPackagesDetails(req, res) {
   let params = {
-    engine: query.engine(req),
+    engine: query.engine(req.query.engine),
     name: query.packageName(req),
   };
   let pack = await database.getPackageByName(params.name);
@@ -313,7 +313,7 @@ async function getPackagesDetails(req, res) {
 
   pack = await utils.constructPackageObjectFull(pack.content);
 
-  if (params.engine) {
+  if (params.engine !== false) {
     // query.engine returns false if no valid query param is found.
     // before using engineFilter we need to check the truthiness of it.
     pack = await utils.engineFilter(pack, params.engine);
@@ -790,7 +790,9 @@ async function postPackagesEventUninstall(req, res) {
   let params = {
     auth: query.auth(req),
     packageName: query.packageName(req),
-    versionName: query.engine(req.params.versionName), // TODO: unused parameter
+    // TODO: versionName unused parameter. On the roadmap to be removed.
+    // See https://github.com/confused-Techie/atom-backend/pull/88#issuecomment-1331809594
+    versionName: query.engine(req.params.versionName),
   };
 
   let user = await auth.verifyAuth(params.auth);

--- a/src/query.js
+++ b/src/query.js
@@ -216,19 +216,20 @@ function packageName(req) {
  * @returns {boolean} True indicates a path traversal attempt was found. False otherwise.
  */
 function pathTraversalAttempt(data) {
-  // this will use several methods to check for the possibility of an attempted path traversal attack.
+  // This will use several methods to check for the possibility of an attempted path traversal attack.
 
-  // The definitions here are based off GoPage checks. https://github.com/confused-Techie/GoPage/blob/main/src/pkg/universalMethods/universalMethods.go
+  // The definitions here are based off GoPage checks.
+  // https://github.com/confused-Techie/GoPage/blob/main/src/pkg/universalMethods/universalMethods.go
   // But we leave out any focused on defended against URL Encoded values, since this has already been decoded.
-  //           unixBackNav, unixBackNavReverse, unixParentCatchAll,
-  const checks = [/\.{2}\//, /\.{2}\\/, /\.{2}/];
+  // const checks = [
+  //   /\.{2}\//,   //unixBackNav
+  //   /\.{2}\\/,   //unixBackNavReverse
+  //   /\.{2}/,     //unixParentCatchAll
+  // ];
 
-  for (let i = 0; i < checks.length; i++) {
-    if (data.match(checks[i]) !== null) {
-      return true;
-    }
-  }
-  return false; // if none of the matches are true.
+  // Combine the 3 regex into one: https://regex101.com/r/CgcZev/1
+  const check = /\.{2}(?:[/\\])?/;
+  return data.match(check) !== null;
 }
 
 module.exports = {

--- a/src/query.js
+++ b/src/query.js
@@ -96,18 +96,11 @@ function query(req) {
 /**
  * @function engine
  * @desc Parses the 'engine' query parameter to ensure its valid, otherwise returning false.
- * @param {object|string} req - The `Request` object inherited from the Express endpoint or the engine string.
+ * @param {string} semver - The engine string.
  * @returns {string|boolean} Returns the valid 'engine' specified, or if none, returns false.
  */
-function engine(req) {
+function engine(semver) {
   try {
-    // adding support for being passed the request object, or a specific version to check.
-    let prov = typeof req === "object" ? req.query.engine : req;
-
-    if (prov === undefined) {
-      return false;
-    }
-
     // Taken from
     // - https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     // - https://regex101.com/r/vkijKf/1/
@@ -117,7 +110,7 @@ function engine(req) {
       /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][\da-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][\da-zA-Z-]*))*))?(?:\+([\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*))?$/;
 
     // Check if it's a valid semver
-    return prov.match(regex) !== null ? prov : false;
+    return semver.match(regex) !== null ? semver : false;
   } catch (e) {
     return false;
   }

--- a/src/tests/query.test.js
+++ b/src/tests/query.test.js
@@ -69,11 +69,13 @@ describe("Verify 'Query' Query Returns", () => {
   });
 });
 
+// query.engine() used to accept both the object and the string,
+// but it has been simplified to accept only the string.
 const engine_cases = [
-  [{ query: { engine: "0.1.2" } }, "0.1.2"],
-  [{ query: { engine: "JustText" } }, false], // should return false to indicate that no check is needed.
-  [{ query: { engine: undefined } }, false],
-  ["2.5.6", "2.5.6"], // Test support for being passed a direct version
+  ["0.1.2", "0.1.2"],
+  ["JustText", false],
+  [undefined, false],
+  ["2.5.6", "2.5.6"],
 ];
 
 describe("Verify Engine Query Returns", () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -319,10 +319,7 @@ async function engineFilter(pack, engine) {
 
       if (
         eqSv !== null &&
-        semverEq(
-          [engSv[1], engSv[2], engSv[3]],
-          [eqSv[1], eqSv[2], eqSv[3]]
-        )
+        semverEq([engSv[1], engSv[2], engSv[3]], [eqSv[1], eqSv[2], eqSv[3]])
       ) {
         compatibleVersion = ver;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -374,7 +374,7 @@ async function engineFilter(pack, engine) {
  * @function semverArray
  * @desc Takes a semver string and return it as an Array of strings
  * @param {string} semver
- * @returns {array} Formatted semver
+ * @returns {array|null} The formatted semver in array of three strings, or null if no match.
  */
 function semverArray(semver) {
   return semver.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

- use one only regex in `pathTraversalAttempt` covering the previous three;
- big refactoring in `git.createPackage`: this could be more robust and faster since less calls to query.engine() are executed. @confused-Techie tests already check the creation of a package or should this be tested manually to discover issues?
- the extraction of the repository object has been split in a new internal function `selectPackageRepository()`;
- looping through the versions, we check also the latest one ensuring to pick the bigger semver even if they are nor sorted (as pointed out [here](https://github.com/confused-Techie/atom-backend/issues/86#issuecomment-1330734284));
- camelCase where possible in `util.js`;
- simplify `query.engine()` to use only the string argument;
- do not select "removed" versions under certain circumstances;