### PR TITLE
Semver constrains, generated columns and integrity on latest versions

### DIFF
--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -151,6 +151,7 @@ with and retreive data from the cloud hosted database instance.
     * [~insertNewPackageName(newName, oldName)](#module_database..insertNewPackageName) ⇒ <code>object</code>
     * [~insertNewUser(user)](#module_database..insertNewUser) ⇒ <code>object</code>
     * [~getPackageByName(name, user)](#module_database..getPackageByName) ⇒ <code>object</code>
+    * [~getPackageByNameSimple(name)](#module_database..getPackageByNameSimple) ⇒ <code>object</code>
     * [~getPackageVersionByNameAndVersion(name, version)](#module_database..getPackageVersionByNameAndVersion) ⇒ <code>object</code>
     * [~getPackageCollectionByName(packArray)](#module_database..getPackageCollectionByName) ⇒ <code>object</code>
     * [~getPackageCollectionByID(packArray)](#module_database..getPackageCollectionByID) ⇒ <code>object</code>
@@ -255,6 +256,19 @@ In that case it's recommended to set the user flag as true for security reasons.
 | --- | --- | --- |
 | name | <code>string</code> | The name of the package. |
 | user | <code>bool</code> | Whether the packages has to be exposed outside or not. If true, all sensitive data like primary and foreign keys are not selected. Even if the keys are ignored by utils.constructPackageObjectFull(), it's still safe to not inclue them in case, by mistake, we publish the return of this module. |
+
+<a name="module_database..getPackageByNameSimple"></a>
+
+### database~getPackageByNameSimple(name) ⇒ <code>object</code>
+Internal util used by other functions in this module to get the package row by the given name.
+It's like getPackageByName(), but with a simple and faster query.
+
+**Kind**: inner method of [<code>database</code>](#module_database)  
+**Returns**: <code>object</code> - A server status object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | The name of the package. |
 
 <a name="module_database..getPackageVersionByNameAndVersion"></a>
 

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -9,7 +9,7 @@
 * Change cost: 8.875739644970414%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 19
 * Logical LOC: 11
@@ -19,7 +19,7 @@
 * Maintainability index: 63.4637930063897
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/config.js
 
 * Physical LOC: 108
 * Logical LOC: 42
@@ -49,7 +49,7 @@
     * Halstead volume: 2667.9089411716054
     * Halstead effort: 89348.7935592373
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -69,7 +69,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -139,7 +139,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -189,7 +189,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -199,7 +199,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 142
 * Logical LOC: 7
@@ -209,7 +209,7 @@
 * Maintainability index: 69.95236801837311
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 123
 * Logical LOC: 71
@@ -219,7 +219,7 @@
 * Maintainability index: 38.82677262118128
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
 
 * Physical LOC: 43
 * Logical LOC: 34
@@ -229,7 +229,7 @@
 * Maintainability index: 50.83192723928399
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
 
 * Physical LOC: 25
 * Logical LOC: 19
@@ -239,7 +239,7 @@
 * Maintainability index: 58.378034894518755
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/lifetime/package-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/package-a.js
 
 * Physical LOC: 37
 * Logical LOC: 27
@@ -249,7 +249,7 @@
 * Maintainability index: 53.446093546666255
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/lifetime/user-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/user-a.js
 
 * Physical LOC: 9
 * Logical LOC: 6

--- a/package-lock.json
+++ b/package-lock.json
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -4003,28 +4003,17 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/formidable/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -10645,9 +10634,9 @@
       }
     },
     "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "requires": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -11465,21 +11454,14 @@
       }
     },
     "formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "requires": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.9.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
-        }
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       }
     },
     "forwarded": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "npm",
         "run",
         "migrations"
-      ]
+      ],
+      "image": "postgres:14.0-alpine"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "run",
         "migrations"
       ],
-      "image": "postgres:14.0-alpine"
+      "image": "postgres:14.5-alpine"
     }
   },
   "dependencies": {

--- a/scripts/database/create_versions_table.sql
+++ b/scripts/database/create_versions_table.sql
@@ -13,3 +13,20 @@ CREATE TABLE versions (
     engine JSONB NOT NULL,
     meta JSONB
 );
+
+-- Constrain to avoiding the duplication of already published versions
+
+ALTER TABLE versions ADD CONSTRAINT unique_pack_version UNIQUE(package, semver);
+
+-- Constrain to force the semantic version 2.0 format
+
+ALTER TABLE versions ADD CONSTRAINT semver2_format CHECK (semver ~ '^\d+\.\d+\.\d+');
+
+-- Generated columns to help sorting by semver
+
+ALTER TABLE versions ADD COLUMN semver_v1 INTEGER
+    GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[1] AS INTEGER)) STORED;
+ALTER TABLE versions ADD COLUMN semver_v2 INTEGER
+    GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[2] AS INTEGER)) STORED;
+ALTER TABLE versions ADD COLUMN semver_v3 INTEGER
+    GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[3] AS INTEGER)) STORED;

--- a/src/database.js
+++ b/src/database.js
@@ -850,7 +850,7 @@ async function removePackageVersion(packName, semVer) {
       const msg =
         typeof err === "string"
           ? err
-          : `A generic error occurred while inserting ${pack.name} package`;
+          : `A generic error occurred while inserting ${packName} package`;
 
       return { ok: false, content: msg, short: "Server Error" };
     });

--- a/src/database.js
+++ b/src/database.js
@@ -106,10 +106,12 @@ async function insertNewPackage(pack) {
         throw `Cannot insert ${pack.name} in names table`;
       }
 
-      // Populate versions table
+      // git.createPackage() executed before this function ensures
+      // the latest version is correctly selected.
       const latest = pack.releases.latest;
-      const pv = pack.versions;
 
+      // Populate versions table
+      const pv = pack.versions;
       for (const ver of Object.keys(pv)) {
         const status = ver === latest ? "latest" : "published";
 

--- a/src/database.js
+++ b/src/database.js
@@ -743,7 +743,7 @@ async function removePackageVersion(packName, semVer) {
 
       const pointer = packID.content.pointer;
 
-      // Retrieve all non-removed versions orderd from latest to older
+      // Retrieve all non-removed versions sorted from latest to older
       const getVersions = await sqlStorage`
         SELECT id, semver, status
         FROM versions
@@ -814,16 +814,18 @@ async function removePackageVersion(packName, semVer) {
       // a new version between the remaining ones which will obtain "latest" status.
       // No need to compare versions here. We have an array ordered from latest to older,
       // just pick the first one not equal to semVer
-      let highestVersionId = null;
+      let latestVersionId = null;
+      let latestSemver = null;
       for (const v of getVersions) {
         if (v.id === versionId) {
           // Skip the removed version
           continue;
         }
-        highestVersionId = v.id;
+        latestVersionId = v.id;
+        latestSemver = v.semver;
       }
 
-      if (highestVersionId === null) {
+      if (latestVersionId === null) {
         throw `An error occurred while selecting the highest versions of ${packName}`;
       }
 
@@ -831,7 +833,7 @@ async function removePackageVersion(packName, semVer) {
       const commandLatest = await sqlStorage`
         UPDATE versions
         SET status = 'latest'
-        WHERE id = ${highestVersionId}
+        WHERE id = ${latestVersionId}
         RETURNING *;
       `;
 

--- a/src/database.js
+++ b/src/database.js
@@ -675,9 +675,9 @@ async function removePackageByName(name) {
         RETURNING *;
       `;
 
-      if (commandStar.count === 0) {
+      /*if (commandStar.count === 0) {
         // No check on deleted stars because the package could also have 0 stars.
-      }
+      }*/
 
       // Remove names related to the package
       const commandName = await sqlStorage`

--- a/src/database.js
+++ b/src/database.js
@@ -816,7 +816,8 @@ async function removePackageVersion(packName, semVer) {
       // just pick the first one not equal to semVer
       let highestVersionId = null;
       for (const v of getVersions) {
-        if (v.id === versionId) { // Skip the removed version
+        if (v.id === versionId) {
+          // Skip the removed version
           continue;
         }
         highestVersionId = v.id;

--- a/src/database.js
+++ b/src/database.js
@@ -186,7 +186,7 @@ async function insertNewPackageVersion(packJSON) {
 
       const higherSemver = utils.semverGt(
         utils.semverArray(packJSON.version),
-        utils.semverArray(latestVersion[0].semver),
+        utils.semverArray(latestVersion[0].semver)
       );
       if (!higherSemver) {
         throw `Cannot publish a new version with semver lower than the current latest one.`;
@@ -1149,7 +1149,8 @@ async function updateDeleteStar(user, pack) {
     }
 
     // if the return matches our input we know it was successful
-    return user.id == commandUnstar[0].userid && pointer == commandUnstar[0].package
+    return user.id == commandUnstar[0].userid &&
+      pointer == commandUnstar[0].package
       ? {
           ok: true,
           content: `Successfully Unstarred ${pointer} with ${user.id}`,

--- a/src/database.js
+++ b/src/database.js
@@ -161,12 +161,10 @@ async function insertNewPackage(pack) {
 async function insertNewPackageVersion(packJSON) {
   sqlStorage ??= setupSQL();
 
+  // We are expected to receive a standard `package.json` file.
   return await sqlStorage
     .begin(async () => {
-      // We first need to collect the needed values to insert into the DB.
-      // The pointer, status, semver, license, engine, meta.
-      // We are expected to receive a standard `package.json` file.
-      const packID = await getPackageByName(packJSON.name);
+      const packID = await getPackageByNameSimple(packJSON.name);
 
       if (!packID.ok) {
         return packID;
@@ -174,11 +172,31 @@ async function insertNewPackageVersion(packJSON) {
 
       const pointer = packID.content.pointer;
 
-      // First we need to change the last 'latest' version, to now just published.
+      // First we need to check if the current latest version is lower than the new one
+      // which we want to publish.
+      const latestVersion = await sqlStorage`
+        SELECT *
+        FROM versions
+        WHERE package = ${pointer} AND status = 'latest';
+      `;
+
+      if (latestVersion.count === 0) {
+        throw `There is no current latest version for ${packJSON.name}. The package is broken.`;
+      }
+
+      const higherSemver = utils.semverGt(
+        utils.semverArray(packJSON.version),
+        utils.semverArray(latestVersion[0].semver),
+      );
+      if (!higherSemver) {
+        throw `Cannot publish a new version with semver lower than the current latest one.`;
+      }
+
+      // The new version can be published. First switch the current "latest" to "published".
       const updateLastVer = await sqlStorage`
         UPDATE versions
         SET status = 'published'
-        WHERE package = ${pointer} AND status = 'latest'
+        WHERE id = ${latestVersion[0].id}
         RETURNING *;
       `;
 
@@ -186,6 +204,7 @@ async function insertNewPackageVersion(packJSON) {
         throw `Unable to modify last published version ${packJSON.name}`;
       }
 
+      // We can insert the new latest version
       const license = packJSON.license ?? "NONE";
       const engine = packJSON.engines ?? { atom: "*" };
 
@@ -229,17 +248,13 @@ async function insertNewPackageName(newName, oldName) {
   return await sqlStorage
     .begin(async () => {
       // Retrieve the package pointer
-      const getID = await sqlStorage`
-        SELECT pointer
-        FROM names
-        WHERE name = ${oldName};
-      `;
+      const packID = await getPackageByNameSimple(oldName);
 
-      if (getID.count === 0) {
+      if (!packID.ok) {
         throw `Unable to find the original pointer of ${oldName}`;
       }
 
-      const pointer = getID[0].pointer;
+      const pointer = packID.content.pointer;
 
       // Before inserting the new name, we try to update it into the `packages` table
       // since we want that column to contain the current name.
@@ -352,6 +367,35 @@ async function getPackageByName(name, user = false) {
         JOIN names n ON (n.pointer = p.pointer)
       WHERE n.name = ${name}
       GROUP BY p.pointer, v.package;
+    `;
+
+    return command.count !== 0
+      ? { ok: true, content: command[0] }
+      : {
+          ok: false,
+          content: `package ${name} not found.`,
+          short: "Not Found",
+        };
+  } catch (err) {
+    return { ok: false, content: err, short: "Server Error" };
+  }
+}
+
+/**
+ * @async
+ * @function getPackageByNameSimple
+ * @desc Internal util used by other functions in this module to get the package row by the given name.
+ * It's like getPackageByName(), but with a simple and faster query.
+ * @param {string} name - The name of the package.
+ * @returns {object} A server status object.
+ */
+async function getPackageByNameSimple(name) {
+  try {
+    sqlStorage ??= setupSQL();
+
+    const command = await sqlStorage`
+      SELECT pointer FROM names
+      WHERE name = ${name};
     `;
 
     return command.count !== 0
@@ -603,18 +647,15 @@ async function removePackageByName(name) {
   return await sqlStorage
     .begin(async () => {
       // Retrieve the package pointer
-      const getID = await sqlStorage`
-        SELECT pointer FROM names
-        WHERE name = ${name};
-      `;
+      const packID = await getPackageByNameSimple(name);
 
-      if (getID.count === 0) {
+      if (!packID.ok) {
         // The package does not exists, but we return ok since it's like
         // it has been deleted.
         return { ok: true, content: `${name} package does not exists.` };
       }
 
-      const pointer = getID[0].pointer;
+      const pointer = packID.content.pointer;
 
       // Remove versions of the package
       const commandVers = await sqlStorage`
@@ -690,17 +731,13 @@ async function removePackageVersion(packName, semVer) {
   return await sqlStorage
     .begin(async () => {
       // Retrieve the package pointer
-      const getID = await sqlStorage`
-        SELECT pointer
-        FROM names
-        WHERE name = ${packName};
-      `;
+      const packID = await getPackageByNameSimple(packName);
 
-      if (getID.count === 0) {
+      if (!packID.ok) {
         throw `Unable to find the pointer of ${packName}`;
       }
 
-      const pointer = getID[0].pointer;
+      const pointer = packID.content.pointer;
 
       // Retrieve all non-removed versions
       const getVersions = await sqlStorage`
@@ -743,7 +780,7 @@ async function removePackageVersion(packName, semVer) {
         throw `It's not possible to leave the ${packName} without at least one published version`;
       }
 
-      // The package will have published versions, so we can remove the targeted semver.
+      // The package will have published versions, so we can remove the targeted semVer.
       const command = await sqlStorage`
         UPDATE versions
         SET status = 'removed'
@@ -1017,12 +1054,9 @@ async function updateStars(user, pack) {
   try {
     sqlStorage ??= setupSQL();
 
-    const commandPointer = await sqlStorage`
-      SELECT pointer FROM names
-      WHERE name = ${pack};
-    `;
+    const packID = await getPackageByNameSimple(pack);
 
-    if (commandPointer.count === 0) {
+    if (!packID.ok) {
       return {
         ok: false,
         content: `Unable to find package ${pack} to star.`,
@@ -1030,26 +1064,25 @@ async function updateStars(user, pack) {
       };
     }
 
-    // else the command is a value, lets keep going
+    const pointer = packID.content.pointer;
 
     const commandStar = await sqlStorage`
       INSERT INTO stars
       (package, userid) VALUES
-      (${commandPointer[0].pointer}, ${user.id})
+      (${pointer}, ${user.id})
       RETURNING *;
     `;
 
     // Now we expect to get our data right back, and can check the
     // validity to know if this happened successfully or not.
-    return commandPointer[0].pointer == commandStar[0].package &&
-      user.id == commandStar[0].userid
+    return pointer == commandStar[0].package && user.id == commandStar[0].userid
       ? {
           ok: true,
-          content: `Successfully Stared ${commandPointer[0].pointer} with ${user.id}`,
+          content: `Successfully Stared ${pointer} with ${user.id}`,
         }
       : {
           ok: false,
-          content: `Failed to Star ${commandPointer[0].pointer} with ${user.id}`,
+          content: `Failed to Star ${pointer} with ${user.id}`,
           short: "Server Error",
         };
   } catch (err) {
@@ -1069,22 +1102,21 @@ async function updateDeleteStar(user, pack) {
   try {
     sqlStorage ??= setupSQL();
 
-    const commandPointer = await sqlStorage`
-      SELECT pointer FROM names
-      WHERE name = ${pack};
-    `;
+    const packID = await getPackageByNameSimple(pack);
 
-    if (commandPointer.count === 0) {
+    if (!packID.ok) {
       return {
         ok: false,
-        content: `Unable to find package ${pack} to star.`,
+        content: `Unable to find package ${pack} to unstar.`,
         short: "Not Found",
       };
     }
 
+    const pointer = packID.content.pointer;
+
     const commandUnstar = await sqlStorage`
       DELETE FROM stars
-      WHERE (package = ${commandPointer[0].pointer}) AND (userid = ${user.id})
+      WHERE (package = ${pointer}) AND (userid = ${user.id})
       RETURNING *;
     `;
 
@@ -1094,7 +1126,7 @@ async function updateDeleteStar(user, pack) {
       const doesExist = await sqlStorage`
         SELECT EXISTS (
           SELECT 1 FROM stars
-          WHERE (package = ${commandPointer[0].pointer}) AND (userid = ${user.id})
+          WHERE (package = ${pointer}) AND (userid = ${user.id})
         );
       `;
 
@@ -1115,15 +1147,14 @@ async function updateDeleteStar(user, pack) {
     }
 
     // if the return matches our input we know it was successful
-    return user.id == commandUnstar[0].userid &&
-      commandPointer[0].pointer == commandUnstar[0].package
+    return user.id == commandUnstar[0].userid && pointer == commandUnstar[0].package
       ? {
           ok: true,
-          content: `Successfully Unstarred ${commandPointer[0].pointer} with ${user.id}`,
+          content: `Successfully Unstarred ${pointer} with ${user.id}`,
         }
       : {
           ok: false,
-          content: `Failed to Unstar ${commandPointer[0].pointer} with ${user.id}`,
+          content: `Failed to Unstar ${pointer} with ${user.id}`,
           short: "Server Error",
         };
   } catch (err) {

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -14,12 +14,16 @@ CREATE TABLE packages (
   data JSONB
 );
 
+ALTER TABLE packages ADD CONSTRAINT lowercase_names CHECK (name = LOWER(name));
+
 -- Create names Table
 
 CREATE TABLE names (
   name VARCHAR(128) NOT NULL PRIMARY KEY,
   pointer UUID NOT NULL REFERENCES packages(pointer)
 );
+
+ALTER TABLE names ADD CONSTRAINT lowercase_names CHECK (name = LOWER(name));
 
 -- Create users Table
 
@@ -53,6 +57,17 @@ CREATE TABLE versions (
     engine JSONB NOT NULL,
     meta JSONB
 );
+
+ALTER TABLE versions ADD CONSTRAINT unique_pack_version UNIQUE(package, semver);
+
+ALTER TABLE versions ADD CONSTRAINT semver2_format CHECK (semver ~ '^\d+\.\d+\.\d+');
+
+ALTER TABLE versions ADD COLUMN semver_v1 INTEGER
+    GENERATED ALWAYS AS CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[1] AS INTEGER) STORED;
+ALTER TABLE versions ADD COLUMN semver_v2 INTEGER
+    GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[2] AS INTEGER)) STORED;
+ALTER TABLE versions ADD COLUMN semver_v3 INTEGER
+    GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[3] AS INTEGER)) STORED;
 
 ------------------------------------------------------------------------------
 

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -63,7 +63,7 @@ ALTER TABLE versions ADD CONSTRAINT unique_pack_version UNIQUE(package, semver);
 ALTER TABLE versions ADD CONSTRAINT semver2_format CHECK (semver ~ '^\d+\.\d+\.\d+');
 
 ALTER TABLE versions ADD COLUMN semver_v1 INTEGER
-    GENERATED ALWAYS AS CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[1] AS INTEGER) STORED;
+    GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[1] AS INTEGER)) STORED;
 ALTER TABLE versions ADD COLUMN semver_v2 INTEGER
     GENERATED ALWAYS AS (CAST ((regexp_match(semver, '^(\d+)\.(\d+)\.(\d+)'))[2] AS INTEGER)) STORED;
 ALTER TABLE versions ADD COLUMN semver_v3 INTEGER

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -125,7 +125,7 @@ async function postPackages(req, res) {
     return;
   }
 
-  const exists = await database.getPackageByName(repo);
+  const exists = await database.getPackageByName(repo, true);
 
   if (exists.ok) {
     // The package exists.
@@ -306,7 +306,7 @@ async function getPackagesDetails(req, res) {
     engine: query.engine(req.query.engine),
     name: query.packageName(req),
   };
-  let pack = await database.getPackageByName(params.name);
+  let pack = await database.getPackageByName(params.name, true);
 
   if (!pack.ok) {
     await common.handleError(req, res, pack, 1004);
@@ -388,7 +388,7 @@ async function postPackagesStar(req, res) {
     return;
   }
 
-  const exists = await database.getPackageByName(params.packageName);
+  const exists = await database.getPackageByName(params.packageName, true);
 
   if (!exists.ok) {
     // The package we are trying to star doesn't exist, resolve with a 404.
@@ -418,7 +418,7 @@ async function postPackagesStar(req, res) {
   }
 
   // Now with a success we want to return the package back in this query
-  let pack = await database.getPackageByName(params.packageName);
+  let pack = await database.getPackageByName(params.packageName, true);
 
   if (!pack.ok) {
     await common.handleError(req, res, pack, 1011);
@@ -491,6 +491,7 @@ async function getPackagesStargazers(req, res) {
   let params = {
     packageName: query.packageName(req),
   };
+  // The following can't be executed in user mode because we need the pointer
   let pack = await database.getPackageByName(params.packageName);
 
   if (!pack.ok) {
@@ -551,7 +552,7 @@ async function postPackagesVersion(req, res) {
   // To support a rename, we need to check if they have permissions over this packages new name.
   // Which means we have to check if they have ownership AFTER we collect it's data.
 
-  let packExists = await database.getPackageByName(params.packageName);
+  let packExists = await database.getPackageByName(params.packageName, true);
 
   if (!packExists.ok) {
     await common.handleError(req, res, packExists);
@@ -775,7 +776,7 @@ async function deletePackageVersion(req, res) {
   }
 
   // Lets also first check to make sure the package exists.
-  let packageExists = await database.getPackageByName(params.packageName);
+  let packageExists = await database.getPackageByName(params.packageName, true);
 
   if (!packageExists.ok) {
     await common.handleError(req, res, packageExists);
@@ -834,7 +835,7 @@ async function postPackagesEventUninstall(req, res) {
 
   // TODO: How does this impact performance? Wonder if we could return
   // the next command with more intelligence to know the pack doesn't exist.
-  let packExists = await database.getPackageByName(params.packageName);
+  let packExists = await database.getPackageByName(params.packageName, true);
 
   if (!packExists.ok) {
     await common.handleError(req, res, packExists);

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -713,7 +713,7 @@ async function getPackagesVersionTarball(req, res) {
 
   // But right before, lets do a couple simple checks to make sure we are sending to a legit site.
   //let tarballURL = new url((pack.content.meta.tarball_url ? pack.content.meta.tarball_url : ""));
-  let tarballURL;
+  let tarballURL = pack.content.meta.tarball_url;
 
   if (tarballURL !== undefined) {
     tarballURL = new url(pack.content.meta.tarball_url);

--- a/src/utils.js
+++ b/src/utils.js
@@ -413,11 +413,10 @@ async function engineFilter(pack, engine) {
  * semverArray("1.Hello.World");
  */
 function semverArray(semver) {
-  let array = semver.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/);
-  if (array.length != 4) {
-    return null; // returning null on no match
-  }
-  return array.slice(1, 4);
+  let array = semver.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/) ?? [];
+
+  // returning null on no match
+  return array.length !== 4 ? null : array.slice(1, 4);
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,7 +74,8 @@ async function constructPackageObjectFull(pack) {
   newPack.name = pack.name;
   newPack.downloads = pack.downloads;
   newPack.stargazers_count =
-    parseInt(pack.stargazers_count, 10) + parseInt(pack.original_stargazers, 10);
+    parseInt(pack.stargazers_count, 10) +
+    parseInt(pack.original_stargazers, 10);
   newPack.versions = parseVersions(pack.versions);
   newPack.releases = {
     latest: findLatestVersion(pack.versions),

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,7 +69,7 @@ async function constructPackageObjectFull(pack) {
   newPack.name = pack.name;
   newPack.downloads = pack.downloads;
   newPack.stargazers_count =
-    parseInt(pack.stargazers_count) + parseInt(pack.original_stargazers);
+    parseInt(pack.stargazers_count, 10) + parseInt(pack.original_stargazers, 10);
   newPack.versions = parseVersions(pack.versions);
   newPack.releases = {
     latest: findLatestVersion(pack.versions),


### PR DESCRIPTION
### Requirements 

* [X] Have you ran tests against this code?

### Description of the Change

**Updated** after the changed suggested by @confused-Techie

Related to #91 
- Added a UNIQUE constrain (`package`, `semver`) on versions table to prevent duplicate versions of the same package;
- Added a CHECK constrain on `versions`.`semver` column to ensure its data adhere to semantic version string format (permissive, check only the first 3 numbers);
- **Introduce generated columns for versions table**
- - we have three new columns `semver_v1`, `semver_v2` and `semver_v3`  automatically generated (no need to input them on insert);
- -  each generated column is an integer related to a single version of the semver; 
- - they will be useful in the future to order versions by semver from latest to older;
- - I plan to use postgreSQL views to be able to query on ordered version to get latest versions easily on javascript code (this will be done in the next weeks if everything goes well...);
- Improve integrity on latest versions ensuring that the new inserted version is higher than the current latest one;
- -  in `insertNewPackageVersion` we first get the latest version from the db: if it's lower than the version we want to insert, we go on, otherwise throw an error.
- A new `getPackageByNameSimple` internal util has been added in `database.js` since in different parts of the module we need the package row by name; we already have something similar, but it's done for package collection outside and has a complex query; so I though to reuse this new one with a simple and faster query to avoid writing `SELECT  * FROM names WHERE name = ${name}`;
- We introduced the `user` flag to not select keys on the `packages` and `versions` tables for safety reasons, but it was only used on one function; I extended it on all other calls that does not need the pointers.

@confused-Techie this is a big one. Take your time to test slowly. First apply the new changes in the database script, then test it.