### PR TITLE
fix postgre begin() + more tests + code refactoring

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -222,7 +222,7 @@ async function insertNewPackageVersion(packJSON) {
         }
       } catch (e) {
         // This occurs when the (package, semver) unique constraint is violated.
-        throw `Not allowed to publish a version previously deleted for ${packJSON.name}`
+        throw `Not allowed to publish a version previously deleted for ${packJSON.name}`;
       }
 
       return {

--- a/src/database.js
+++ b/src/database.js
@@ -370,12 +370,15 @@ async function getPackageByName(name, user = false) {
           user ? sqlStorage`` : sqlStorage`p.pointer,`
         } p.name, p.created, p.updated, p.creation_method,
         p.downloads, p.stargazers_count, p.original_stargazers, p.data,
-        JSONB_AGG(JSON_BUILD_OBJECT(
-          ${
-            user ? sqlStorage`` : sqlStorage`'id', v.id, 'package', v.package,`
-          } 'status', v.status, 'semver', v.semver,
-          'license', v.license, 'engine', v.engine, 'meta', v.meta
-        )) AS versions
+        JSONB_AGG(
+          JSON_BUILD_OBJECT(
+            ${
+              user ? sqlStorage`` : sqlStorage`'id', v.id, 'package', v.package,`
+            } 'status', v.status, 'semver', v.semver,
+            'license', v.license, 'engine', v.engine, 'meta', v.meta
+          )
+          ORDER BY v.semver_v1 DESC, v.semver_v2 DESC, v.semver_v3 DESC
+        ) AS versions
       FROM packages p
         JOIN versions v ON (p.pointer = v.package) AND (v.status != 'removed')
         JOIN names n ON (n.pointer = p.pointer)

--- a/src/database.js
+++ b/src/database.js
@@ -191,7 +191,7 @@ async function insertNewPackageVersion(packJSON) {
         utils.semverArray(latestVersion[0].semver)
       );
       if (!higherSemver) {
-        throw `Cannot publish a new version with semver lower than the current latest one.`;
+        throw `Cannot publish a new version with semver lower or equal than the current latest one.`;
       }
 
       // The new version can be published. First switch the current "latest" to "published".
@@ -217,7 +217,7 @@ async function insertNewPackageVersion(packJSON) {
       `;
 
       if (addVer.count === 0) {
-        throw `Unable to create new version: ${packJSON.name}`;
+        throw `Unable to create a new version for ${packJSON.name}`;
       }
 
       return {

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -32,7 +32,7 @@ const url = require("url");
  * @property {http_endpoint} - /api/packages
  */
 async function getPackages(req, res) {
-  let params = {
+  const params = {
     page: query.page(req),
     sort: query.sort(req),
     direction: query.dir(req),
@@ -51,7 +51,7 @@ async function getPackages(req, res) {
 
   packages = await utils.constructPackageObjectShort(packages.content);
 
-  let totalPages = await database.getTotalPackageEstimate();
+  const totalPages = await database.getTotalPackageEstimate();
 
   if (!totalPages.ok) {
     await common.handleError(req, res, totalPages, 1002);
@@ -91,12 +91,12 @@ async function getPackages(req, res) {
  * @property {http_endpoint} - /api/packages
  */
 async function postPackages(req, res) {
-  let params = {
+  const params = {
     repository: query.repo(req),
     auth: query.auth(req),
   };
 
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   // Check authentication.
   if (!user.ok) {
@@ -149,7 +149,7 @@ async function postPackages(req, res) {
   }
 
   // Now knowing they own the git repo, and it doesn't exist here, lets publish.
-  let newPack = await git.createPackage(params.repository, user.content);
+  const newPack = await git.createPackage(params.repository, user.content);
 
   if (!newPack.ok) {
     await common.handleError(req, res, newPack);
@@ -157,7 +157,7 @@ async function postPackages(req, res) {
   }
 
   // Now with valid package data, we can insert them into the DB.
-  let insertedNewPack = await database.insertNewPackage(newPack.content);
+  const insertedNewPack = await database.insertNewPackage(newPack.content);
 
   if (!insertedNewPack.ok) {
     await common.handleError(req, res, insertedNewPack);
@@ -167,7 +167,7 @@ async function postPackages(req, res) {
   // Finally we can return what was actually put into the database.
   // Retrieve the data from database.getPackageByName() and
   // convert it into Package Object Full format.
-  let newDbPack = await database.getPackageByName(repo, true);
+  const newDbPack = await database.getPackageByName(repo, true);
 
   if (!newDbPack.ok) {
     common.serverError(req, res, "Cannot retrieve new package from DB");
@@ -197,14 +197,14 @@ async function postPackages(req, res) {
 async function getPackagesFeatured(req, res) {
   // Returns Package Object Short array.
   // Supports engine query parameter.
-  let col = await database.getFeaturedPackages();
+  const col = await database.getFeaturedPackages();
 
   if (!col.ok) {
     await common.handleError(req, res, col, 1003);
     return;
   }
 
-  let newCol = await utils.constructPackageObjectShort(col.content);
+  const newCol = await utils.constructPackageObjectShort(col.content);
 
   res.status(200).json(newCol);
   logger.httpLog(req, res);
@@ -224,7 +224,7 @@ async function getPackagesFeatured(req, res) {
  * rather than simple search.
  */
 async function getPackagesSearch(req, res) {
-  let params = {
+  const params = {
     sort: query.sort(req, "relevance"),
     page: query.page(req),
     direction: query.dir(req),
@@ -302,7 +302,7 @@ async function getPackagesSearch(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName
  */
 async function getPackagesDetails(req, res) {
-  let params = {
+  const params = {
     engine: query.engine(req.query.engine),
     name: query.packageName(req),
   };
@@ -335,19 +335,19 @@ async function getPackagesDetails(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName
  */
 async function deletePackagesName(req, res) {
-  let params = {
+  const params = {
     auth: query.auth(req),
     packageName: query.packageName(req),
   };
 
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   if (!user.ok) {
     await common.handleError(req, res, user, 1005);
     return;
   }
 
-  let gitowner = await git.ownership(user.content, params.packageName);
+  const gitowner = await git.ownership(user.content, params.packageName);
 
   if (!gitowner.ok) {
     await common.handleError(req, res, gitowner, 4001);
@@ -355,7 +355,7 @@ async function deletePackagesName(req, res) {
   }
 
   // Now they are logged in locally, and have permission over the GitHub repo.
-  let rm = await database.removePackageByName(params.packageName);
+  const rm = await database.removePackageByName(params.packageName);
 
   if (!rm.ok) {
     await common.handleError(req, res, rm, 1006);
@@ -376,12 +376,12 @@ async function deletePackagesName(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
 async function postPackagesStar(req, res) {
-  let params = {
+  const params = {
     auth: query.auth(req),
     packageName: query.packageName(req),
   };
 
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   if (!user.ok) {
     await common.handleError(req, res, user, 1008);
@@ -401,14 +401,14 @@ async function postPackagesStar(req, res) {
     return;
   }
 
-  let star = await database.updateStars(user.content, params.packageName);
+  const star = await database.updateStars(user.content, params.packageName);
 
   if (!star.ok) {
     await common.handleError(req, res, user, 1009);
     return;
   }
 
-  let updatePack = await database.updatePackageIncrementStarByName(
+  const updatePack = await database.updatePackageIncrementStarByName(
     params.packageName
   );
 
@@ -441,19 +441,19 @@ async function postPackagesStar(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
 async function deletePackagesStar(req, res) {
-  let params = {
+  const params = {
     auth: query.auth(req),
     packageName: query.packageName(req),
   };
 
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   if (!user.ok) {
     await common.handleError(req, res, user);
     return;
   }
 
-  let unstar = await database.updateDeleteStar(
+  const unstar = await database.updateDeleteStar(
     user.content,
     params.packageName
   );
@@ -463,7 +463,7 @@ async function deletePackagesStar(req, res) {
     return;
   }
 
-  let updatePack = await database.updatePackageDecrementStarByName(
+  const updatePack = await database.updatePackageDecrementStarByName(
     params.packageName
   );
 
@@ -488,25 +488,25 @@ async function deletePackagesStar(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/stargazers
  */
 async function getPackagesStargazers(req, res) {
-  let params = {
+  const params = {
     packageName: query.packageName(req),
   };
   // The following can't be executed in user mode because we need the pointer
-  let pack = await database.getPackageByName(params.packageName);
+  const pack = await database.getPackageByName(params.packageName);
 
   if (!pack.ok) {
     await common.handleError(req, res, pack);
     return;
   }
 
-  let stars = await database.getStarringUsersByPointer(pack.content);
+  const stars = await database.getStarringUsersByPointer(pack.content);
 
   if (!stars.ok) {
     await common.handleError(req, res, stars);
     return;
   }
 
-  let gazers = await database.getUserCollectionById(stars.content);
+  const gazers = await database.getUserCollectionById(stars.content);
 
   if (!gazers.ok) {
     await common.handleError(req, res, gazers);
@@ -528,7 +528,7 @@ async function getPackagesStargazers(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/versions
  */
 async function postPackagesVersion(req, res) {
-  let params = {
+  const params = {
     tag: query.tag(req),
     rename: query.rename(req),
     auth: query.auth(req),
@@ -542,7 +542,7 @@ async function postPackagesVersion(req, res) {
   // And if they are, we expect that `auth` is true. Because otherwise it will fail.
   // That's the methodology, the logic here just needs to catch up.
 
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   if (!user.ok) {
     await common.handleError(req, res, user);
@@ -552,7 +552,7 @@ async function postPackagesVersion(req, res) {
   // To support a rename, we need to check if they have permissions over this packages new name.
   // Which means we have to check if they have ownership AFTER we collect it's data.
 
-  let packExists = await database.getPackageByName(params.packageName, true);
+  const packExists = await database.getPackageByName(params.packageName, true);
 
   if (!packExists.ok) {
     await common.handleError(req, res, packExists);
@@ -562,7 +562,7 @@ async function postPackagesVersion(req, res) {
   // Now it's important to note, that getPackageJSON was intended to be an internal function.
   // As such does not return a Server Status Object. This may change later, but for now,
   // we will expect `undefined` to not be success.
-  let packJSON = await git.getPackageJSON(
+  const packJSON = await git.getPackageJSON(
     `${user.content.username}/${packExists.name}`,
     user.content
   );
@@ -589,7 +589,7 @@ async function postPackagesVersion(req, res) {
   // Else we will continue, and trust the name provided from the package as being accurate.
   // And now we can ensure the user actually owns this repo, with our updated name.
 
-  let gitowner = await git.ownership(user.content, packJSON.name);
+  const gitowner = await git.ownership(user.content, packJSON.name);
 
   if (!gitowner.ok) {
     await common.handleError(req, res, gitowner);
@@ -601,7 +601,7 @@ async function postPackagesVersion(req, res) {
 
   if (packJSON.name !== params.packageName && params.rename) {
     // The flow for renaming the existing package.
-    let newName = await database.insertNewPackageName(
+    const newName = await database.insertNewPackageName(
       packJSON.name,
       params.packageName
     );
@@ -614,7 +614,7 @@ async function postPackagesVersion(req, res) {
 
   // Now add the new Version key.
 
-  let addVer = await database.insertNewPackageVersion(packJSON);
+  const addVer = await database.insertNewPackageVersion(packJSON);
 
   if (!addVer.ok) {
     await common.handleError(req, res, addVer);
@@ -635,7 +635,7 @@ async function postPackagesVersion(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
 async function getPackagesVersion(req, res) {
-  let params = {
+  const params = {
     packageName: query.packageName(req),
     versionName: query.engine(req.params.versionName),
   };
@@ -647,7 +647,7 @@ async function getPackagesVersion(req, res) {
   }
   // Now we know the version is a valid semver.
 
-  let pack = await database.getPackageVersionByNameAndVersion(
+  const pack = await database.getPackageVersionByNameAndVersion(
     params.packageName,
     params.versionName
   );
@@ -657,7 +657,7 @@ async function getPackagesVersion(req, res) {
     return;
   }
 
-  let packRes = await utils.constructPackageObjectJSON(pack.content);
+  const packRes = await utils.constructPackageObjectJSON(pack.content);
 
   res.status(200).json(packRes);
   logger.httpLog(req, res);
@@ -674,7 +674,7 @@ async function getPackagesVersion(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName/tarball
  */
 async function getPackagesVersionTarball(req, res) {
-  let params = {
+  const params = {
     packageName: query.packageName(req),
     versionName: query.engine(req.params.versionName),
   };
@@ -690,7 +690,7 @@ async function getPackagesVersionTarball(req, res) {
   }
 
   // first lets get the package
-  let pack = await database.getPackageVersionByNameAndVersion(
+  const pack = await database.getPackageVersionByNameAndVersion(
     params.packageName,
     params.versionName
   );
@@ -700,7 +700,7 @@ async function getPackagesVersionTarball(req, res) {
     return;
   }
 
-  let save = await database.updatePackageIncrementDownloadByName(
+  const save = await database.updatePackageIncrementDownloadByName(
     params.packageName
   );
 
@@ -754,21 +754,21 @@ async function getPackagesVersionTarball(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
 async function deletePackageVersion(req, res) {
-  let params = {
+  const params = {
     auth: query.auth(req),
     packageName: query.packageName(req),
     versionName: query.engine(req.params.versionName),
   };
 
   // Verify the user has local and remote permissions
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   if (!user.ok) {
     await common.handleError(req, res, user);
     return;
   }
 
-  let gitowner = await git.ownership(user.content, params.packageName);
+  const gitowner = await git.ownership(user.content, params.packageName);
 
   if (!gitowner.ok) {
     await common.handleError(req, res, gitowner);
@@ -776,7 +776,7 @@ async function deletePackageVersion(req, res) {
   }
 
   // Lets also first check to make sure the package exists.
-  let packageExists = await database.getPackageByName(params.packageName, true);
+  const packageExists = await database.getPackageByName(params.packageName, true);
 
   if (!packageExists.ok) {
     await common.handleError(req, res, packageExists);
@@ -790,7 +790,7 @@ async function deletePackageVersion(req, res) {
   }
 
   // Mark the specified version for deletion, if version is valid
-  let removeVersion = await database.removePackageVersion(
+  const removeVersion = await database.removePackageVersion(
     params.packageName,
     params.versionName
   );
@@ -818,7 +818,7 @@ async function deletePackageVersion(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName/events/uninstall
  */
 async function postPackagesEventUninstall(req, res) {
-  let params = {
+  const params = {
     auth: query.auth(req),
     packageName: query.packageName(req),
     // TODO: versionName unused parameter. On the roadmap to be removed.
@@ -826,7 +826,7 @@ async function postPackagesEventUninstall(req, res) {
     versionName: query.engine(req.params.versionName),
   };
 
-  let user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth);
 
   if (!user.ok) {
     await common.handleError(req, res, user);
@@ -835,14 +835,14 @@ async function postPackagesEventUninstall(req, res) {
 
   // TODO: How does this impact performance? Wonder if we could return
   // the next command with more intelligence to know the pack doesn't exist.
-  let packExists = await database.getPackageByName(params.packageName, true);
+  const packExists = await database.getPackageByName(params.packageName, true);
 
   if (!packExists.ok) {
     await common.handleError(req, res, packExists);
     return;
   }
 
-  let write = await database.updatePackageDecrementDownloadByName(
+  const write = await database.updatePackageDecrementDownloadByName(
     params.packageName
   );
 

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -236,7 +236,7 @@ async function getPackagesSearch(req, res) {
   // side. This is only an effort to get this working quickly and should be changed later.
   // This also means for now, the default sorting method will be downloads, not relevance.
 
-  let packs = await database.simpleSearch(
+  const packs = await database.simpleSearch(
     params.query,
     params.page,
     params.direction,
@@ -266,11 +266,11 @@ async function getPackagesSearch(req, res) {
     // See: https://github.com/confused-Techie/atom-backend/issues/59
   }
 
-  let totalPageEstimate = await database.getTotalPackageEstimate();
+  const totalPageEstimate = await database.getTotalPackageEstimate();
 
-  let totalPages = !totalPageEstimate.ok ? 1 : totalPageEstimate.content;
+  const totalPages = !totalPageEstimate.ok ? 1 : totalPageEstimate.content;
 
-  let safeQuery = params.query.replace(/[^a-zA-Z0-9_\-\s*\.]/gi, "");
+  const safeQuery = encodeURIComponent(params.query.replace(/[<>"':;\\/]+/g, ""));
   // now to get headers.
   res.append(
     "Link",

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -130,6 +130,16 @@ describe("Tests against semverArray", () => {
     expect(res[1]).toEqual("4180");
     expect(res[2]).toEqual("2");
   });
+  test("Returns invalid data for an invalid string format", () => {
+    const ver = " 1.2.3";
+    const res = utils.semverArray(ver);
+    expect(res).toEqual(null);
+  });
+  test("Returns invalid data for types different than string", () => {
+    const ver = null;
+    const res = utils.semverArray(ver);
+    expect(res).toEqual(null);
+  });
 });
 
 describe("Tests against semverGt", () => {

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -194,15 +194,17 @@ describe("Package Lifecycle Tests", () => {
     );
 
     // === Let's see if this new version is the latest
+    // The versions are sorted by latest to older, so
+    // index 0 is the latest, index 1 is the older.
     const getAfterVer = await database.getPackageByName(NEW_NAME);
     expect(getAfterVer.ok).toBeTruthy();
     expect(getAfterVer.content.versions.length).toEqual(2);
-    expect(getAfterVer.content.versions[1].semver).toEqual(v1_0_1.version);
-    expect(getAfterVer.content.versions[1].status).toEqual("latest");
-    expect(getAfterVer.content.versions[1].license).toEqual(v1_0_1.license);
-    expect(getAfterVer.content.versions[1].meta.name).toEqual(v1_0_1.name);
-    expect(getAfterVer.content.versions[1].meta.version).toEqual(v1_0_1.version);
-    expect(getAfterVer.content.versions[0].semver).toEqual(pack.createPack.metadata.version);
+    expect(getAfterVer.content.versions[0].semver).toEqual(v1_0_1.version);
+    expect(getAfterVer.content.versions[0].status).toEqual("latest");
+    expect(getAfterVer.content.versions[0].license).toEqual(v1_0_1.license);
+    expect(getAfterVer.content.versions[0].meta.name).toEqual(v1_0_1.name);
+    expect(getAfterVer.content.versions[0].meta.version).toEqual(v1_0_1.version);
+    expect(getAfterVer.content.versions[1].semver).toEqual(pack.createPack.metadata.version);
 
     // === Can we publish a duplicate or a lower version?
     const dupVer = await database.insertNewPackageVersion(v1_0_1);

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -135,7 +135,7 @@ describe("Package Lifecycle Tests", () => {
     );
     expect(newName.ok).toBeTruthy();
     expect(newName.content).toEqual(
-      "Successfully inserted package-a-lifetime-rename."
+      `Successfully inserted ${NEW_NAME}.`
     );
 
     // === Can we get the package by it's new name?
@@ -156,6 +156,19 @@ describe("Package Lifecycle Tests", () => {
     expect(
       getByOldName.content.updated >= getAfterPublish.content.updated
     ).toBeTruthy();
+
+    // === Can we rename with an already used name?
+    // This should fail because there's a unique constraint on names, not only
+    // for the single package, but the entire table, i.e. two packages cannot
+    // have the same name.
+    const renameToExistingName = await database.insertNewPackageName(
+      pack.createPack.name,
+      NEW_NAME
+    );
+    expect(renameToExistingName.ok).toBeFalsy();
+    expect(renameToExistingName.content).toEqual(
+      `Unable to add the new name: ${pack.createPack.name} is already used.`
+    );
 
     // === Now let's try to delete the only version available.
     // This should fail because the package needs to have at least

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -194,7 +194,7 @@ describe("Package Lifecycle Tests", () => {
     );
 
     // === Let's see if this new version is the latest
-    // The versions are sorted by latest to older, so
+    // The versions are sorted from latest to oldest, so
     // index 0 is the latest, index 1 is the older.
     const getAfterVer = await database.getPackageByName(NEW_NAME);
     expect(getAfterVer.ok).toBeTruthy();

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -291,13 +291,10 @@ describe("Package Lifecycle Tests", () => {
     // higher than the previous latest one in order to trigger an update to the user.
     const reAddNextVersion = await database.insertNewPackageVersion(v1_0_1);
     const latestVer = await database.getPackageByName(NEW_NAME);
-    // Should be latest, but it's published.
-    console.log(latestVer.content.versions);
     expect(reAddNextVersion.ok).toBeFalsy();
-    // Let's skip this for the moment
-    /*expect(reAddNextVersion.content).toEqual(
-      `Unable to create a new version for ${v1_0_1.name}`
-    );*/
+    expect(reAddNextVersion.content).toEqual(
+      `Not allowed to publish a version previously deleted for ${v1_0_1.name}`
+    );
 
     // === Can we delete a version lower than the current latest?
     // First let's push a new version.

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -317,6 +317,16 @@ describe("Package Lifecycle Tests", () => {
       `Successfully removed ${pack.createPack.metadata.version} version of ${NEW_NAME} package.`
     );
 
+    // === Can we remove a non-existing version?
+    const removeNonExistingVersion = await database.removePackageVersion(
+      NEW_NAME,
+      pack.createPack.metadata.version
+    );
+    expect(removeNonExistingVersion.ok).toBeFalsy();
+    expect(removeNonExistingVersion.content).toEqual(
+      `There's no version ${pack.createPack.metadata.version} to remove for ${NEW_NAME} package`
+    );
+
     // === Can we delete the entire package?
     const delPack = await database.removePackageByName(NEW_NAME);
     expect(delPack.ok).toBeTruthy();

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -157,7 +157,9 @@ describe("Package Lifecycle Tests", () => {
       getByOldName.content.updated >= getAfterPublish.content.updated
     ).toBeTruthy();
 
-    // === Now let's try to delete the only version available. This should fail.
+    // === Now let's try to delete the only version available.
+    // This should fail because the package needs to have at least
+    // one published (latest) version.
     const removeOnlyVersion = await database.removePackageVersion(
       NEW_NAME,
       pack.createPack.metadata.version
@@ -305,8 +307,15 @@ describe("Package Lifecycle Tests", () => {
     expect(addNewVersion.content).toEqual(
       `Successfully added new version: ${newVersion.name}@${newVersion.version}`
     );
-
-    // TODO: Delete the first version
+    // Delete the oldest version.
+    const removeOldestVersion = await database.removePackageVersion(
+      NEW_NAME,
+      pack.createPack.metadata.version
+    );
+    expect(removeOldestVersion.ok).toBeTruthy();
+    expect(removeOldestVersion.content).toEqual(
+      `Successfully removed ${pack.createPack.metadata.version} version of ${NEW_NAME} package.`
+    );
 
     // === Can we delete the entire package?
     const delPack = await database.removePackageByName(NEW_NAME);

--- a/src/tests_integration/fixtures/lifetime/package-a.js
+++ b/src/tests_integration/fixtures/lifetime/package-a.js
@@ -24,14 +24,16 @@ const createPack = {
   },
 };
 
-const nextVersion = {
-  name: "package-a-lifetime",
-  version: "1.0.1",
-  description: "A package.json description",
-  license: "MIT",
-};
+const addVersion = (v) => {
+  return {
+    name: "package-a-lifetime",
+    version: v,
+    description: "A package.json description",
+    license: "MIT",
+  };
+}
 
 module.exports = {
   createPack,
-  nextVersion,
+  addVersion,
 };

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -288,6 +288,10 @@ describe("GET /api/packages/:packageName", () => {
     const res = await request(app).get("/api/packages/LanguAge-CSs");
     expect(res.body.name).toBe("language-css");
   });
+  test("Valid package, does not return sensible data (package pointer)", async () => {
+    const res = await request(app).get("/api/packages/language-css");
+    expect(res.body.pointer).toBe(undefined);
+  });
   test("Valid package, gives success status code", async () => {
     const res = await request(app).get("/api/packages/language-css");
     expect(res).toHaveHTTPCode(200);

--- a/src/utils.js
+++ b/src/utils.js
@@ -414,7 +414,9 @@ async function engineFilter(pack, engine) {
  * semverArray("1.Hello.World");
  */
 function semverArray(semver) {
-  let array = semver.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/) ?? [];
+  let array = typeof semver === "string"
+    ? (semver.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/) ?? [])
+    : [];
 
   // returning null on no match
   return array.length !== 4 ? null : array.slice(1, 4);


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

Related to #91. This contains all the commits of #97 plus an additional one which shows an issue.

Which are the steps of the tests:

1. We have a starting package with 1.0.0 version.

2. Add a new 1.0.1 version. OK 

3. Insert a duplicate 1.0.1 version. This has to fail. OK
- - This fails because we compare the semver. If it's lower or equal, we exit.

- In the current state we have:
- - version 1.0.0 published
- - version 1.0.1 latest 

4. Remove 1.0.1 version. OK
- - With checks we perform, the version is marked as removed and the remaining highest published one is converted as latest.

- In the current state we have:
- - version 1.0.0 latest
- - version 1.0.1 removed

5. Check if 1.0.0 is the latest. OK

6. Insert a previous deleted package. Try to reinsert 1.0.1 version. This has to fail. OK
- -  Why we want this to fail. @confused-Techie citation: 
> if I download version 1.0.1 but there's some critical bug or secret within it, and the author pulls it off the store, then uploads again, if they kept the same version, I would personally never see an update and keep running this insecure, secret riddled version
- - This won't fail on semver comparison because the version is higher. That's why we added the (package, semver) unique constraint to prevent this insertion.

7. **The previous step fails as we want but the rollback is not applied!**
- - Before inserting the new version, we convert the current latest version to published status and this operation is saved. If the rollback worked, this was not saved.

- In the current state we have:
- - version 1.0.0 published
- - version 1.0.1 removed 

8. Show the log of `latestVer.content.versions`. We clearly see the only non removed version is published, not latest.

9. Insert a new 1.1.0 version. FAILS
- - Indeed this fails because there are no latest versions as we check inside `insertNewPackageVersion`. So this confirm the rollback is not applied. 

So I wonder why it's not working. I read the **[doc](https://github.com/porsager/postgres#readme)** of the module and it seems that whenever we go into the catch statement, the rollback should be performed. I also applied "`read write`" options, but nothing changes.

This has to be investigated because we need transactions and in the current state begin function is useless.