### PR TITLE
Fix stargazers issue + more tests on data validity + code refactoring

### DIFF
--- a/docs/reference/API_Definition.md
+++ b/docs/reference/API_Definition.md
@@ -244,7 +244,7 @@ Unauthorized.
 
 ---
 # **[POST]** /api/packages/:packageName/star
-Star a packge.
+Star a package.
 
 Auth: `true`
 Parameters:
@@ -486,7 +486,7 @@ Parameters:
 
 ---
 * packageName _(required)_  | Location: `path`  
-  - The name of the packge to modify.
+  - The name of the package to modify.
 
 
 ---

--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -408,9 +408,8 @@ package.
 <a name="module_database..getFeaturedThemes"></a>
 
 ### database~getFeaturedThemes() ⇒ <code>object</code>
-Collects the hardcoded featured themes array from the sotrage.js
-module. Then uses this.getPackageCollectionByName to retreive details of the
-package.
+Collects the hardcoded featured themes array from the storage.js module.
+Then uses this.getPackageCollectionByName to retreive details of the package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -1089,7 +1088,7 @@ A helper for any functions that are agnostic in handlers.
     * [~StateStore](#module_utils..StateStore)
     * [~isPackageNameBanned(name)](#module_utils..isPackageNameBanned) ⇒ <code>object</code>
     * [~constructPackageObjectFull(pack)](#module_utils..constructPackageObjectFull) ⇒ <code>object</code>
-    * [~constructPackageObjectShort(pack)](#module_utils..constructPackageObjectShort) ⇒ <code>object</code>
+    * [~constructPackageObjectShort(pack)](#module_utils..constructPackageObjectShort) ⇒ <code>object</code> \| <code>array</code>
     * [~constructPackageObjectJSON(pack)](#module_utils..constructPackageObjectJSON) ⇒ <code>object</code>
     * [~engineFilter()](#module_utils..engineFilter) ⇒ <code>object</code>
     * [~semverArray(semver)](#module_utils..semverArray) ⇒ <code>array</code> \| <code>null</code>
@@ -1144,12 +1143,12 @@ otherwise the behavior is unexpected.
 
 <a name="module_utils..constructPackageObjectShort"></a>
 
-### utils~constructPackageObjectShort(pack) ⇒ <code>object</code>
+### utils~constructPackageObjectShort(pack) ⇒ <code>object</code> \| <code>array</code>
 Takes a single or array of rows from the db, and returns a JSON
 construction of package object shorts
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
-**Returns**: <code>object</code> - A properly formatted and converted Package Object Short.  
+**Returns**: <code>object</code> \| <code>array</code> - A properly formatted and converted Package Object Short.  
 **See**
 
 - [https://github.com/confused-Techie/atom-backend/blob/main/docs/returns.md#package-object-short](https://github.com/confused-Techie/atom-backend/blob/main/docs/returns.md#package-object-short)

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -9,7 +9,7 @@
 * Change cost: 8.284023668639055%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 23
 * Logical LOC: 12
@@ -19,7 +19,7 @@
 * Maintainability index: 62.36361563140606
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -49,7 +49,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -119,7 +119,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -169,7 +169,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/config.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/config.test.js
 
 * Physical LOC: 63
 * Logical LOC: 2
@@ -179,7 +179,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -189,7 +189,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 95
 * Logical LOC: 4
@@ -199,7 +199,7 @@
 * Maintainability index: 76.39879935103494
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 143
 * Logical LOC: 78
@@ -209,7 +209,7 @@
 * Maintainability index: 37.635938926624725
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
 
 * Physical LOC: 43
 * Logical LOC: 34
@@ -219,7 +219,7 @@
 * Maintainability index: 50.83192723928399
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
 
 * Physical LOC: 25
 * Logical LOC: 19
@@ -229,7 +229,7 @@
 * Maintainability index: 58.378034894518755
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/lifetime/package-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/package-a.js
 
 * Physical LOC: 39
 * Logical LOC: 23
@@ -239,7 +239,7 @@
 * Maintainability index: 55.494411910399926
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/lifetime/user-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/user-a.js
 
 * Physical LOC: 9
 * Logical LOC: 6

--- a/src/database.js
+++ b/src/database.js
@@ -443,7 +443,7 @@ async function getPackageVersionByNameAndVersion(name, version) {
     sqlStorage ??= setupSQL();
 
     const command = await sqlStorage`
-      SELECT *
+      SELECT semver, status, license, engine, meta
       FROM versions
       WHERE package IN (
         SELECT pointer

--- a/src/database.js
+++ b/src/database.js
@@ -369,8 +369,8 @@ async function getPackageByName(name, user = false) {
       SELECT
         ${
           user ? sqlStorage`` : sqlStorage`p.pointer,`
-        } p.name, p.created, p.updated, p.creation_method,
-        p.downloads, p.stargazers_count, p.original_stargazers, p.data,
+        } p.name, p.created, p.updated, p.creation_method, p.downloads,
+        (p.stargazers_count + p.original_stargazers) AS stargazers_count, p.data,
         JSONB_AGG(
           JSON_BUILD_OBJECT(
             ${

--- a/src/database.js
+++ b/src/database.js
@@ -914,9 +914,7 @@ async function getFeaturedThemes() {
     return featuredThemeArray;
   }
 
-  return await getPackageCollectionByName(
-    featuredThemeArray.content
-  );
+  return await getPackageCollectionByName(featuredThemeArray.content);
 }
 
 /**
@@ -1362,7 +1360,9 @@ async function getSortedPackages(page, dir, method) {
     const command = await sqlStorage`
       SELECT p.data, p.downloads, (p.stargazers_count + p.original_stargazers) AS stargazers_count, v.semver
       FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
-      ORDER BY ${orderType} ${dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`}
+      ORDER BY ${orderType} ${
+      dir === "desc" ? sqlStorage`DESC` : sqlStorage`ASC`
+    }
       LIMIT ${limit}
       OFFSET ${offset};
     `;

--- a/src/database.js
+++ b/src/database.js
@@ -477,8 +477,11 @@ async function getPackageCollectionByName(packArray) {
   try {
     sqlStorage ??= setupSQL();
 
+    // Since this function is invoked by getFeaturedThemes and getFeaturedPackages
+    // which process the returned content with constructPackageObjectShort(),
+    // we select only the needed columns.
     const command = await sqlStorage`
-      SELECT *
+      SELECT p.data, p.downloads, p.stargazers_count, p.original_stargazers, v.semver
       FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
       WHERE pointer IN (
         SELECT pointer FROM names
@@ -903,9 +906,8 @@ async function getFeaturedPackages() {
 /**
  * @async
  * @function getFeaturedThemes
- * @desc Collects the hardcoded featured themes array from the sotrage.js
- * module. Then uses this.getPackageCollectionByName to retreive details of the
- * package.
+ * @desc Collects the hardcoded featured themes array from the storage.js module.
+ * Then uses this.getPackageCollectionByName to retreive details of the package.
  * @returns {object} A server status object.
  */
 async function getFeaturedThemes() {

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -212,16 +212,21 @@ async function postPackages(req, res) {
 async function getPackagesFeatured(req, res) {
   // Returns Package Object Short array.
   // Supports engine query parameter.
-  const col = await database.getFeaturedPackages();
+  const packs = await database.getFeaturedPackages();
 
-  if (!col.ok) {
-    await common.handleError(req, res, col, 1003);
+  if (!packs.ok) {
+    await common.handleError(req, res, packs, 1003);
     return;
   }
 
-  const newCol = await utils.constructPackageObjectShort(col.content);
+  const packObjShort = await utils.constructPackageObjectShort(packs.content);
 
-  res.status(200).json(newCol);
+  // The endpoint using this function needs an array.
+  const respArray = Array.isArray(packObjShort)
+    ? packObjShort
+    : [packObjShort];
+
+  res.status(200).json(respArray);
   logger.httpLog(req, res);
 }
 

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -38,7 +38,7 @@ async function getPackages(req, res) {
     direction: query.dir(req),
   };
 
-  let packages = await database.getSortedPackages(
+  const packages = await database.getSortedPackages(
     params.page,
     params.direction,
     params.sort
@@ -53,7 +53,12 @@ async function getPackages(req, res) {
     return;
   }
 
-  packages = await utils.constructPackageObjectShort(packages.content);
+  const packObjShort = await utils.constructPackageObjectShort(packages.content);
+
+  // The endpoint using this function needs an array.
+  const packArray = Array.isArray(packObjShort)
+    ? packObjShort
+    : [packObjShort];
 
   const totalPages = await database.getTotalPackageEstimate();
 
@@ -81,7 +86,7 @@ async function getPackages(req, res) {
     }&order=${params.direction}>; rel="next"`
   );
 
-  res.status(200).json(packages);
+  res.status(200).json(packArray);
   logger.httpLog(req, res);
 }
 
@@ -249,11 +254,11 @@ async function getPackagesFeatured(req, res) {
   const packObjShort = await utils.constructPackageObjectShort(packs.content);
 
   // The endpoint using this function needs an array.
-  const respArray = Array.isArray(packObjShort)
+  const packArray = Array.isArray(packObjShort)
     ? packObjShort
     : [packObjShort];
 
-  res.status(200).json(respArray);
+  res.status(200).json(packArray);
   logger.httpLog(req, res);
 }
 
@@ -311,17 +316,22 @@ async function getPackagesSearch(req, res) {
     return;
   }
 
-  let newPacks = await utils.constructPackageObjectShort(packs.content);
+  const newPacks = await utils.constructPackageObjectShort(packs.content);
+  let packArray = null;
 
-  if (Object.keys(newPacks).length < 1) {
+  if (Array.isArray(newPacks)) {
+    packArray = newPacks;
+  } else if (Object.keys(newPacks).length < 1) {
+    packArray = [];
     logger.generic(
       4,
       "getPackagesSearch-simpleSearch Responding with Empty Array for 0 Key Length Object"
     );
-    newPacks = [];
     // This also helps protect against misreturned searches. As in getting a 404 rather
     // than empty search results.
     // See: https://github.com/confused-Techie/atom-backend/issues/59
+  } else {
+    packArray = [newPacks];
   }
 
   const totalPageEstimate = await database.getTotalPackageEstimate();
@@ -347,7 +357,7 @@ async function getPackagesSearch(req, res) {
     }&sort=${params.sort}&order=${params.direction}>; rel="next"`
   );
 
-  res.status(200).json(newPacks);
+  res.status(200).json(packArray);
   logger.httpLog(req, res);
 }
 

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -53,12 +53,12 @@ async function getPackages(req, res) {
     return;
   }
 
-  const packObjShort = await utils.constructPackageObjectShort(packages.content);
+  const packObjShort = await utils.constructPackageObjectShort(
+    packages.content
+  );
 
   // The endpoint using this function needs an array.
-  const packArray = Array.isArray(packObjShort)
-    ? packObjShort
-    : [packObjShort];
+  const packArray = Array.isArray(packObjShort) ? packObjShort : [packObjShort];
 
   const totalPages = await database.getTotalPackageEstimate();
 
@@ -254,9 +254,7 @@ async function getPackagesFeatured(req, res) {
   const packObjShort = await utils.constructPackageObjectShort(packs.content);
 
   // The endpoint using this function needs an array.
-  const packArray = Array.isArray(packObjShort)
-    ? packObjShort
-    : [packObjShort];
+  const packArray = Array.isArray(packObjShort) ? packObjShort : [packObjShort];
 
   res.status(200).json(packArray);
   logger.httpLog(req, res);

--- a/src/main.js
+++ b/src/main.js
@@ -406,7 +406,7 @@ app.delete("/api/:packType/:packageName", authLimit, async (req, res, next) => {
  * @path /api/packages/:packageName/star
  * @method POST
  * @auth true
- * @desc Star a packge.
+ * @desc Star a package.
  * @param
  *   @name packType
  *   @location path
@@ -750,7 +750,7 @@ app.delete(
  *   @name packageName
  *   @location path
  *   @required true
- *   @Pdesc The name of the packge to modify.
+ *   @Pdesc The name of the package to modify.
  * @param
  *   @name versionName
  *   @location path

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -254,13 +254,6 @@ describe("Package Lifecycle Tests", () => {
     );
     expect(getOldVerOnly.content.meta.name).toEqual(pack.createPack.name);
 
-    // === Can we star our package?
-    const starPack = await database.updatePackageIncrementStarByName(NEW_NAME);
-    expect(starPack.ok).toBeTruthy();
-    expect(starPack.content.name).toEqual(NEW_NAME);
-    expect(starPack.content.stargazers_count).toEqual("1");
-    expect(starPack.content.original_stargazers).toEqual("0");
-
     // === Can we add a download to our package?
     const downPack = await database.updatePackageIncrementDownloadByName(
       NEW_NAME
@@ -277,6 +270,20 @@ describe("Package Lifecycle Tests", () => {
     expect(downPackUndo.content.name).toEqual(NEW_NAME);
     expect(downPackUndo.content.downloads).toEqual("0");
 
+    // === Can we get the download count od our package below zero?
+    const downPackReUndo = await database.updatePackageDecrementDownloadByName(
+      NEW_NAME
+    );
+    expect(downPackReUndo.ok).toBeTruthy();
+    expect(downPackReUndo.content.name).toEqual(NEW_NAME);
+    expect(downPackReUndo.content.downloads).toEqual("0");
+
+    // === Can we star our package?
+    const starPack = await database.updatePackageIncrementStarByName(NEW_NAME);
+    expect(starPack.ok).toBeTruthy();
+    expect(starPack.content.name).toEqual(NEW_NAME);
+    expect(starPack.content.stargazers_count).toEqual("1");
+
     // === Can we unstar our package?
     const starPackUndo = await database.updatePackageDecrementStarByName(
       NEW_NAME
@@ -284,7 +291,14 @@ describe("Package Lifecycle Tests", () => {
     expect(starPackUndo.ok).toBeTruthy();
     expect(starPackUndo.content.name).toEqual(NEW_NAME);
     expect(starPackUndo.content.stargazers_count).toEqual("0");
-    expect(starPackUndo.content.original_stargazers).toEqual("0");
+
+    // === Can we get the stars of our package below zero?
+    const starPackReUndo = await database.updatePackageDecrementStarByName(
+      NEW_NAME
+    );
+    expect(starPackReUndo.ok).toBeTruthy();
+    expect(starPackReUndo.content.name).toEqual(NEW_NAME);
+    expect(starPackReUndo.content.stargazers_count).toEqual("0");
 
     // === Can we star by the old name?
     const starPackOld = await database.updatePackageIncrementStarByName(

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -122,8 +122,8 @@ describe("Package Lifecycle Tests", () => {
       pack.createPack.creation_method
     );
     expect(getAfterPublish.content.downloads).toEqual("0");
+    // Original stargazers already added to stargazers count
     expect(getAfterPublish.content.stargazers_count).toEqual("0");
-    expect(getAfterPublish.content.original_stargazers).toEqual("0");
     expect(getAfterPublish.content.data.name).toEqual(pack.createPack.name);
     expect(getAfterPublish.content.data.readme).toEqual(pack.createPack.readme);
     expect(getAfterPublish.content.data.repository).toEqual(

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -124,6 +124,23 @@ describe("Get /api/packages", () => {
     const res = await request(app).get("/api/packages");
     expect(res).toHaveHTTPCode(200);
   });
+  test("Should respond with an array containing valid data", async () => {
+    const res = await request(app).get("/api/packages");
+    for (const p of res.body) {
+      expect(typeof p.name === "string").toBeTruthy();
+      // PostgreSQL numeric types are not fully compatible with js Number type
+      expect((`${p.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
+      expect((`${p.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+      expect(typeof p.releases.latest === "string").toBeTruthy();
+    }
+  });
+  test("Should respond with an array not containing sensible data", async () => {
+    const res = await request(app).get("/api/packages");
+    for (const p of res.body) {
+      // Use type coercion to catch also undefined
+      expect(p.pointer == null).toBeTruthy();
+    }
+  });
   test("Should 404 on invalid Method", async () => {
     const res = await request(app).patch("/api/packages");
     expect(res).toHaveHTTPCode(404);
@@ -239,17 +256,18 @@ describe("GET /api/packages/featured", () => {
   test("Returns Valid Data", async () => {
     const res = await request(app).get("/api/packages/featured");
     for (const p of res.body) {
-      // Use type coercion to catch also undefined
-      expect(p.data == null).toBeFalsy();
-      expect(isNaN(p.stargazers_count)).toBeFalsy();
-      expect(typeof p.semver === "string").toBeTruthy();
+      expect(typeof p.name === "string").toBeTruthy();
+      // PostgreSQL numeric types are not fully compatible with js Number type
+      expect((`${p.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
+      expect((`${p.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+      expect(typeof p.releases.latest === "string").toBeTruthy();
     }
   });
   test("Does Not Return Sensible Data", async () => {
     const res = await request(app).get("/api/packages/featured");
     for (const p of res.body) {
+      // Use type coercion to catch also undefined
       expect(p.pointer == null).toBeTruthy();
-      expect(p.id == null).toBeTruthy();
     }
   });
 });
@@ -262,6 +280,23 @@ describe("GET /api/packages/search", () => {
   test("Valid Search Returns Success Status Code", async () => {
     const res = await request(app).get("/api/packages/search?q=language");
     expect(res).toHaveHTTPCode(200);
+  });
+  test("Valid Search Returns Valid Data", async () => {
+    const res = await request(app).get("/api/packages/search?q=language");
+    for (const p of res.body) {
+      expect(typeof p.name === "string").toBeTruthy();
+      // PostgreSQL numeric types are not fully compatible with js Number type
+      expect((`${p.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
+      expect((`${p.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+      expect(typeof p.releases.latest === "string").toBeTruthy();
+    }
+  });
+  test("Valid Search Does Not Return Sensible Data", async () => {
+    const res = await request(app).get("/api/packages/search?q=language");
+    for (const p of res.body) {
+      // Use type coercion to catch also undefined
+      expect(p.pointer == null).toBeTruthy();
+    }
   });
   test("Invalid Search Returns Array", async () => {
     const res = await request(app).get("/api/packages/search?q=not-one-match");

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -339,9 +339,24 @@ describe("GET /api/packages/:packageName", () => {
     const res = await request(app).get("/api/packages/LanguAge-CSs");
     expect(res.body.name).toBe("language-css");
   });
-  test("Valid package, does not return sensible data (package pointer)", async () => {
+  test("Valid package contains valid data", async () => {
     const res = await request(app).get("/api/packages/language-css");
-    expect(res.body.pointer).toBe(undefined);
+    // PostgreSQL numeric types are not fully compatible with js Number type
+    expect((`${res.body.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
+    expect((`${res.body.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+    expect(typeof res.body.releases.latest === "string").toBeTruthy();
+    for (const v of Object.keys(res.body.versions)) {
+      expect(typeof res.body.versions[v].license === "string").toBeTruthy();
+    }
+  });
+  test("Valid package, does not return sensible data", async () => {
+    const res = await request(app).get("/api/packages/language-css");
+    // Use type coercion to catch also undefined
+    expect(res.body.pointer == null).toBeTruthy();
+    for (const v of Object.keys(res.body.versions)) {
+      expect(res.body.versions[v].id == null).toBeTruthy();
+      expect(res.body.versions[v].package == null).toBeTruthy();
+    }
   });
   test("Valid package, gives success status code", async () => {
     const res = await request(app).get("/api/packages/language-css");

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -129,8 +129,8 @@ describe("Get /api/packages", () => {
     for (const p of res.body) {
       expect(typeof p.name === "string").toBeTruthy();
       // PostgreSQL numeric types are not fully compatible with js Number type
-      expect((`${p.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
-      expect((`${p.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.stargazers_count}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.downloads}`.match(/^\d+$/) === null).toBeFalsy();
       expect(typeof p.releases.latest === "string").toBeTruthy();
     }
   });
@@ -258,8 +258,8 @@ describe("GET /api/packages/featured", () => {
     for (const p of res.body) {
       expect(typeof p.name === "string").toBeTruthy();
       // PostgreSQL numeric types are not fully compatible with js Number type
-      expect((`${p.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
-      expect((`${p.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.stargazers_count}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.downloads}`.match(/^\d+$/) === null).toBeFalsy();
       expect(typeof p.releases.latest === "string").toBeTruthy();
     }
   });
@@ -286,8 +286,8 @@ describe("GET /api/packages/search", () => {
     for (const p of res.body) {
       expect(typeof p.name === "string").toBeTruthy();
       // PostgreSQL numeric types are not fully compatible with js Number type
-      expect((`${p.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
-      expect((`${p.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.stargazers_count}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.downloads}`.match(/^\d+$/) === null).toBeFalsy();
       expect(typeof p.releases.latest === "string").toBeTruthy();
     }
   });
@@ -342,8 +342,8 @@ describe("GET /api/packages/:packageName", () => {
   test("Valid package contains valid data", async () => {
     const res = await request(app).get("/api/packages/language-css");
     // PostgreSQL numeric types are not fully compatible with js Number type
-    expect((`${res.body.stargazers_count}`).match(/^\d+$/) === null).toBeFalsy();
-    expect((`${res.body.downloads}`).match(/^\d+$/) === null).toBeFalsy();
+    expect(`${res.body.stargazers_count}`.match(/^\d+$/) === null).toBeFalsy();
+    expect(`${res.body.downloads}`.match(/^\d+$/) === null).toBeFalsy();
     expect(typeof res.body.releases.latest === "string").toBeTruthy();
     for (const v of Object.keys(res.body.versions)) {
       expect(typeof res.body.versions[v].license === "string").toBeTruthy();

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -626,11 +626,21 @@ describe("GET /api/packages/:packageName/versions/:versionName", () => {
     );
     expect(res).toHaveHTTPCode(200);
   });
-  test("Returns Expected Package Name with Valid Params", async () => {
+  test("Returns Valid Data on Expected Package Name with Valid Params", async () => {
     const res = await request(app).get(
       "/api/packages/language-css/versions/0.45.7"
     );
     expect(res.body.name).toEqual("language-css");
+    expect(typeof res.body.dist.tarball === "string").toBeTruthy();
+  });
+  test("Does Not Return Sensible Data on Expected Package Name with Valid Params", async () => {
+    const res = await request(app).get(
+      "/api/packages/language-css/versions/0.45.7"
+    );
+    // Use type coercion to catch also undefined
+    expect(res.body.id == null).toBeTruthy();
+    expect(res.body.package == null).toBeTruthy();
+    expect(res.body.sha == null).toBeTruthy();
   });
 });
 

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -236,6 +236,22 @@ describe("GET /api/packages/featured", () => {
     const res = await request(app).get("/api/packages/featured");
     expect(res.body).toBeArray();
   });
+  test("Returns Valid Data", async () => {
+    const res = await request(app).get("/api/packages/featured");
+    for (const p of res.body) {
+      // Use type coercion to catch also undefined
+      expect(p.data == null).toBeFalsy();
+      expect(isNaN(p.stargazers_count)).toBeFalsy();
+      expect(typeof p.semver === "string").toBeTruthy();
+    }
+  });
+  test("Does Not Return Sensible Data", async () => {
+    const res = await request(app).get("/api/packages/featured");
+    for (const p of res.body) {
+      expect(p.pointer == null).toBeTruthy();
+      expect(p.id == null).toBeTruthy();
+    }
+  });
 });
 
 describe("GET /api/packages/search", () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,9 +73,7 @@ async function constructPackageObjectFull(pack) {
   let newPack = pack.data;
   newPack.name = pack.name;
   newPack.downloads = pack.downloads;
-  newPack.stargazers_count =
-    parseInt(pack.stargazers_count, 10) +
-    parseInt(pack.original_stargazers, 10);
+  newPack.stargazers_count = pack.stargazers_count;
   newPack.versions = parseVersions(pack.versions);
   newPack.releases = {
     latest: findLatestVersion(pack.versions),

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,7 @@ async function constructPackageObjectFull(pack) {
   const parseVersions = function (vers) {
     let retVer = {};
 
-    for (let v of vers) {
+    for (const v of vers) {
       retVer[v.semver] = v.meta;
       retVer[v.semver].license = v.license;
       retVer[v.semver].engine = v.engine;
@@ -107,17 +107,16 @@ async function constructPackageObjectShort(pack) {
         "Package Object Short Constructor Protected against 0 Length Array"
       );
 
-      return [];
+      return pack;
     }
     let retPacks = [];
 
-    for (let i = 0; i < pack.length; i++) {
-      let newPack = pack[i].data;
-      newPack.downloads = pack[i].downloads;
-      newPack.stargazers_count =
-        parseInt(pack.stargazers_count, 10) + parseInt(pack.original_stargazers, 10);
+    for (const p of pack) {
+      let newPack = p.data;
+      newPack.downloads = p.downloads;
+      newPack.stargazers_count = p.stargazers_count;
       newPack.releases = {
-        latest: pack[i].semver,
+        latest: p.semver,
       };
       retPacks.push(newPack);
     }
@@ -131,7 +130,6 @@ async function constructPackageObjectShort(pack) {
     pack.data === undefined ||
     pack.downloads === undefined ||
     pack.stargazers_count === undefined ||
-    pack.original_stargazers === undefined ||
     pack.semver === undefined
   ) {
     logger.generic(
@@ -179,14 +177,14 @@ async function constructPackageObjectJSON(pack) {
 
   let arrPack = [];
 
-  for (let i = 0; i < pack.length; i++) {
-    let newPack = pack[i].meta;
+  for (const p of pack) {
+    let newPack = p.meta;
     if (newPack.sha) {
       delete newPack.sha;
     }
     newPack.dist ??= {};
-    newPack.dist.tarball = `${server_url}/api/packages/${pack[i].meta.name}/versions/${pack[i].semver}/tarball`;
-    newPack.engines = pack[i].engine;
+    newPack.dist.tarball = `${server_url}/api/packages/${p.meta.name}/versions/${p.semver}/tarball`;
+    newPack.engines = p.engine;
     arrPack.push(newPack);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,7 +115,7 @@ async function constructPackageObjectShort(pack) {
       let newPack = pack[i].data;
       newPack.downloads = pack[i].downloads;
       newPack.stargazers_count =
-        parseInt(pack.stargazers_count) + parseInt(pack.original_stargazers);
+        parseInt(pack.stargazers_count, 10) + parseInt(pack.original_stargazers, 10);
       newPack.releases = {
         latest: pack[i].semver,
       };

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,7 +104,7 @@ async function constructPackageObjectShort(pack) {
       latest: p.semver,
     };
     return newPack;
-  }
+  };
 
   if (Array.isArray(pack)) {
     if (pack.length === 0) {
@@ -167,10 +167,10 @@ async function constructPackageObjectJSON(pack) {
     newPack.engines = v.engine;
     logger.generic(6, "Single Package Object JSON finished without Error");
     return newPack;
-  }
+  };
 
   if (!Array.isArray(pack)) {
-    const newPack = parseVersionObject(pack)
+    const newPack = parseVersionObject(pack);
 
     logger.generic(6, "Single Package Object JSON finished without Error");
     return newPack;

--- a/src/utils.js
+++ b/src/utils.js
@@ -93,7 +93,7 @@ async function constructPackageObjectFull(pack) {
  * construction of package object shorts
  * @param {object} pack - The anticipated raw SQL return that contains all data
  * to construct a Package Object Short.
- * @returns {object} A properly formatted and converted Package Object Short.
+ * @returns {object|array} A properly formatted and converted Package Object Short.
  * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/returns.md#package-object-short}
  * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/queries.md#retrieve-many-sorted-packages--package-object-short}
  */
@@ -131,6 +131,7 @@ async function constructPackageObjectShort(pack) {
     pack.data === undefined ||
     pack.downloads === undefined ||
     pack.stargazers_count === undefined ||
+    pack.original_stargazers === undefined ||
     pack.semver === undefined
   ) {
     logger.generic(


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This started yesterday and continued today. Do not count the first 3 commit which I couldn't test yesterday because of the issue that has been fixed.

- Fixed the stargazers issue since it's postgreSQL bigint type which is not always returned as a Number, but a string on big values. My approach is to not handle it by javascript, but generate it from SQL summing the original stargazers. No more parseInt on them.
- Lots of tests on data validity and integrity of returned arrays/objects. Especially ensuring sensible data like pointers and versions id are not exposed in the responses.

@confused-Techie please double check this even if tests are passing.