### PR TITLE
New stargazers management + Package renaming in transaction

### DIFF
--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -160,7 +160,7 @@ with and retreive data from the cloud hosted database instance.
     * [~setupSQL()](#module_database..setupSQL) ⇒ <code>object</code>
     * [~shutdownSQL()](#module_database..shutdownSQL)
     * [~insertNewPackage(pack)](#module_database..insertNewPackage) ⇒ <code>object</code>
-    * [~insertNewPackageVersion(packJSON)](#module_database..insertNewPackageVersion) ⇒ <code>object</code>
+    * [~insertNewPackageVersion(packJSON, oldName)](#module_database..insertNewPackageVersion) ⇒ <code>object</code>
     * [~insertNewPackageName(newName, oldName)](#module_database..insertNewPackageName) ⇒ <code>object</code>
     * [~insertNewUser(user)](#module_database..insertNewUser) ⇒ <code>object</code>
     * [~getPackageByName(name, user)](#module_database..getPackageByName) ⇒ <code>object</code>
@@ -168,8 +168,7 @@ with and retreive data from the cloud hosted database instance.
     * [~getPackageVersionByNameAndVersion(name, version)](#module_database..getPackageVersionByNameAndVersion) ⇒ <code>object</code>
     * [~getPackageCollectionByName(packArray)](#module_database..getPackageCollectionByName) ⇒ <code>object</code>
     * [~getPackageCollectionByID(packArray)](#module_database..getPackageCollectionByID) ⇒ <code>object</code>
-    * [~updatePackageIncrementStarByName(name)](#module_database..updatePackageIncrementStarByName) ⇒ <code>object</code>
-    * [~updatePackageDecrementStarByName(name)](#module_database..updatePackageDecrementStarByName) ⇒ <code>object</code>
+    * [~updatePackageStargazers(name, pointer)](#module_database..updatePackageStargazers) ⇒ <code>object</code>
     * [~updatePackageIncrementDownloadByName(name)](#module_database..updatePackageIncrementDownloadByName) ⇒ <code>object</code>
     * [~updatePackageDecrementDownloadByName(name)](#module_database..updatePackageDecrementDownloadByName) ⇒ <code>object</code>
     * [~removePackageByName(name)](#module_database..removePackageByName) ⇒ <code>object</code>
@@ -180,8 +179,8 @@ with and retreive data from the cloud hosted database instance.
     * [~getUserByName(username)](#module_database..getUserByName) ⇒ <code>object</code>
     * [~getUserByNodeID(id)](#module_database..getUserByNodeID) ⇒ <code>object</code>
     * [~getUserByID(id)](#module_database..getUserByID) ⇒ <code>object</code>
-    * [~updateStars(user, pack)](#module_database..updateStars) ⇒ <code>object</code>
-    * [~updateDeleteStar(user, pack)](#module_database..updateDeleteStar) ⇒ <code>object</code>
+    * [~updateIncrementStar(user, pack)](#module_database..updateIncrementStar) ⇒ <code>object</code>
+    * [~updateDecrementStar(user, pack)](#module_database..updateDecrementStar) ⇒ <code>object</code>
     * [~getStarredPointersByUserID(userid)](#module_database..getStarredPointersByUserID) ⇒ <code>object</code>
     * [~getStarringUsersByPointer(pointer)](#module_database..getStarringUsersByPointer) ⇒ <code>object</code>
     * [~simpleSearch()](#module_database..simpleSearch) ⇒ <code>object</code>
@@ -218,7 +217,7 @@ Insert a new package inside the DB taking a `Server Object Full` as argument.
 
 <a name="module_database..insertNewPackageVersion"></a>
 
-### database~insertNewPackageVersion(packJSON) ⇒ <code>object</code>
+### database~insertNewPackageVersion(packJSON, oldName) ⇒ <code>object</code>
 Adds a new package version to the db.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
@@ -227,6 +226,7 @@ Adds a new package version to the db.
 | Param | Type | Description |
 | --- | --- | --- |
 | packJSON | <code>object</code> | A full `package.json` file for the wanted version. |
+| oldName | <code>string</code> \| <code>null</code> | If provided, the old name to be replaced for the renaming of the package. |
 
 <a name="module_database..insertNewPackageName"></a>
 
@@ -236,6 +236,12 @@ This essentially renames an existing package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
+**Todo**
+
+- [ ] This function has been left only for testing purpose since it has been integrated
+inside insertNewPackageVersion, so it should be removed when we can test the rename process
+directly on the endpoint.
+
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -321,22 +327,10 @@ Takes a package pointer array, and returns an array of the package objects.
 | --- | --- | --- |
 | packArray | <code>Array.&lt;int&gt;</code> | An array of package id. |
 
-<a name="module_database..updatePackageIncrementStarByName"></a>
+<a name="module_database..updatePackageStargazers"></a>
 
-### database~updatePackageIncrementStarByName(name) ⇒ <code>object</code>
-Uses the package name to increment it's stargazers count by one.
-
-**Kind**: inner method of [<code>database</code>](#module_database)  
-**Returns**: <code>object</code> - The effected server status object.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| name | <code>string</code> | The package name. |
-
-<a name="module_database..updatePackageDecrementStarByName"></a>
-
-### database~updatePackageDecrementStarByName(name) ⇒ <code>object</code>
-Uses the package name to decrement it's stargazers count by one.
+### database~updatePackageStargazers(name, pointer) ⇒ <code>object</code>
+Uses the package name (or pointer if provided) to update its stargazers count.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - The effected server status object.  
@@ -344,6 +338,7 @@ Uses the package name to decrement it's stargazers count by one.
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | The package name. |
+| pointer | <code>string</code> | The package id (if given, the search by name is skipped). |
 
 <a name="module_database..updatePackageIncrementDownloadByName"></a>
 
@@ -457,9 +452,9 @@ Get user details providing their ID.
 | --- | --- | --- |
 | id | <code>int</code> | User ID |
 
-<a name="module_database..updateStars"></a>
+<a name="module_database..updateIncrementStar"></a>
 
-### database~updateStars(user, pack) ⇒ <code>object</code>
+### database~updateIncrementStar(user, pack) ⇒ <code>object</code>
 Register the star given by a user to a package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
@@ -470,9 +465,9 @@ Register the star given by a user to a package.
 | user | <code>int</code> | A User Object that should star the package. |
 | pack | <code>string</code> | Package name that get the new star. |
 
-<a name="module_database..updateDeleteStar"></a>
+<a name="module_database..updateDecrementStar"></a>
 
-### database~updateDeleteStar(user, pack) ⇒ <code>object</code>
+### database~updateDecrementStar(user, pack) ⇒ <code>object</code>
 Register the removal of the star on a package by a user.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
@@ -487,6 +482,7 @@ Register the removal of the star on a package by a user.
 
 ### database~getStarredPointersByUserID(userid) ⇒ <code>object</code>
 Get all packages which the user gave the star.
+The result of this function should not be returned to the user because it contains pointers UUID.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  

--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -859,7 +859,7 @@ engine(): Returns false if not defined, to allow a fast way to determine if resu
 
 
 * [query](#module_query)
-    * [~page(req)](#module_query..page) ⇒ <code>string</code>
+    * [~page(req)](#module_query..page) ⇒ <code>number</code>
     * [~sort(req, [def])](#module_query..sort) ⇒ <code>string</code>
     * [~dir(req)](#module_query..dir) ⇒ <code>string</code>
     * [~query(req)](#module_query..query) ⇒ <code>string</code>
@@ -874,11 +874,11 @@ engine(): Returns false if not defined, to allow a fast way to determine if resu
 
 <a name="module_query..page"></a>
 
-### query~page(req) ⇒ <code>string</code>
+### query~page(req) ⇒ <code>number</code>
 Parser of the Page query parameter. Defaulting to 1.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
-**Returns**: <code>string</code> - Returns the valid page provided in the query parameter or 1, as the default.  
+**Returns**: <code>number</code> - Returns the valid page provided in the query parameter or 1, as the default.  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -9,7 +9,7 @@
 * Change cost: 8.284023668639055%
 * Core size: 100%
 
-## /home/runner/work/atom-backend/atom-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 23
 * Logical LOC: 12
@@ -19,7 +19,7 @@
 * Maintainability index: 62.36361563140606
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -49,7 +49,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/atom-backend/atom-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -119,7 +119,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/atom-backend/atom-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -169,7 +169,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/config.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/config.test.js
 
 * Physical LOC: 63
 * Logical LOC: 2
@@ -179,7 +179,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -189,7 +189,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 95
 * Logical LOC: 4
@@ -199,7 +199,7 @@
 * Maintainability index: 76.39879935103494
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 143
 * Logical LOC: 78
@@ -209,7 +209,7 @@
 * Maintainability index: 37.635938926624725
 * Dependency count: 1
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
 
 * Physical LOC: 43
 * Logical LOC: 34
@@ -219,7 +219,7 @@
 * Maintainability index: 50.83192723928399
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
 
 * Physical LOC: 25
 * Logical LOC: 19
@@ -229,7 +229,7 @@
 * Maintainability index: 58.378034894518755
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/lifetime/package-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/package-a.js
 
 * Physical LOC: 39
 * Logical LOC: 23
@@ -239,7 +239,7 @@
 * Maintainability index: 55.494411910399926
 * Dependency count: 0
 
-## /home/runner/work/atom-backend/atom-backend/src/tests_integration/fixtures/lifetime/user-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/user-a.js
 
 * Physical LOC: 9
 * Logical LOC: 6

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -3,8 +3,8 @@
 * Mean per-function logical LOC: 17.153846153846153
 * Mean per-function parameter count: 0.36538461538461536
 * Mean per-function cyclomatic complexity: 1.5769230769230769
-* Mean per-function Halstead effort: 5118.06282754091
-* Mean per-module maintainability index: 64.53863313132871
+* Mean per-function Halstead effort: 5043.95238437846
+* Mean per-module maintainability index: 64.54258539120397
 * First-order density: 0.591715976331361%
 * Change cost: 8.284023668639055%
 * Core size: 100%
@@ -206,7 +206,7 @@
 * Mean parameter count: 0
 * Cyclomatic complexity: 1
 * Cyclomatic complexity density: 1.282051282051282%
-* Maintainability index: 37.635938926624725
+* Maintainability index: 37.68731830500316
 * Dependency count: 1
 
 ## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js

--- a/scripts/database/create_packages_table.sql
+++ b/scripts/database/create_packages_table.sql
@@ -16,9 +16,12 @@ CREATE TABLE packages (
     data JSONB
 );
 
+-- Lowercase constraint
 -- https://github.com/confused-Techie/atom-backend/issues/90
 
 ALTER TABLE packages ADD CONSTRAINT lowercase_names CHECK (name = LOWER(name));
+
+-- Add packageType column
 
 ALTER TABLE packages ADD COLUMN package_type VARCHAR(20);
 
@@ -30,8 +33,28 @@ UPDATE packages
 SET package_type = 'package'
 WHERE package_type IS DISTINCT FROM 'theme';
 
+-- Create packageType enum type
+
 CREATE TYPE packageType AS ENUM('package', 'theme');
+
+-- Cast existing values of package_type in packageType
 
 ALTER TABLE packages
 ALTER COLUMN package_type TYPE packageType USING (package_type::packageType),
 ALTER COLUMN package_type SET NOT NULL;
+
+-- Create a function and a trigger to set the current timestamp
+-- in the `updated` column of the updated row
+
+CREATE FUNCTION now_on_updated_package()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER trigger_now_on_updated
+    BEFORE UPDATE ON packages
+    FOR EACH ROW
+EXECUTE PROCEDURE now_on_updated_package();

--- a/src/auth.js
+++ b/src/auth.js
@@ -90,10 +90,10 @@ async function verifyAuth(token) {
       }
     }
 
-    let prov_node_id = user_data.body.node_id;
+    const prov_node_id = user_data.body.node_id;
 
     // Now we want to see if we are able to locate this user's node_id in our db.
-    let db_user = await database.getUserByNodeID(prov_node_id);
+    const db_user = await database.getUserByNodeID(prov_node_id);
 
     if (!db_user.ok) {
       return db_user;
@@ -102,7 +102,7 @@ async function verifyAuth(token) {
     // Now we have a valid user from the database, that we can confirm is fully authenticated.
     // We will go ahead and return an "Auth User Object" to let the rest of the system use
 
-    let auth_user_object = {
+    const auth_user_object = {
       token: token,
       id: db_user.content.id,
       node_id: prov_node_id,

--- a/src/database.js
+++ b/src/database.js
@@ -1166,6 +1166,7 @@ async function updateDecrementStar(user, pack) {
  * @async
  * @function getStarredPointersByUserID
  * @description Get all packages which the user gave the star.
+ * The result of this function should not be returned to the user because it contains pointers UUID.
  * @param {int} userid - ID of the user.
  * @returns {object} A server status object.
  */
@@ -1179,14 +1180,12 @@ async function getStarredPointersByUserID(userid) {
       );
     `;
 
-    let packArray = command[0].array;
-
-    if (command.count === 0) {
-      // It is likely safe to assume that if nothing matches the userid,
-      // then the user hasn't given any star. So instead of server error
-      // here we will non-traditionally return an empty array.
-      packArray = [];
-    }
+    // It is likely safe to assume that if nothing matches the userid,
+    // then the user hasn't given any star. So instead of server error
+    // here we will non-traditionally return an empty array.
+    const packArray = (command.count !== 0 && Array.isArray(command[0].array))
+      ? command[0].array
+      : [];
 
     return { ok: true, content: packArray };
   } catch (err) {

--- a/src/database.js
+++ b/src/database.js
@@ -1140,43 +1140,28 @@ async function updateDecrementStar(user, pack) {
     `;
 
     if (commandUnstar.length === 0) {
-      // The command failed, let see if its because the data doesn't exist.
-
-      const doesExist = await sqlStorage`
-        SELECT EXISTS (
-          SELECT 1 FROM stars
-          WHERE (package = ${pointer}) AND (userid = ${user.id})
-        );
-      `;
-
-      if (doesExist[0].exists) {
-        // Exists is true, so it failed for some other reason
-        return {
-          ok: false,
-          content: `Failed to Unstar ${pack} with ${user.username}`,
-          short: "Server Error",
-        };
-      }
-
+      // We know user and package exist both, so the fail is because
+      // the star was already missing,
+      // The user expects its star is not given, so we return ok.
       return {
-        ok: false,
-        content: `Failed to Unstar ${pack} with ${user.username} Because it doesn't exist.`,
-        short: "Not Found",
+        ok: true,
+        content: "The Star is Already Missing",
       };
     }
 
-    // if the return matches our input we know it was successful
-    return user.id == commandUnstar[0].userid &&
-      pointer == commandUnstar[0].package
-      ? {
-          ok: true,
-          content: "Successfully Unstarred",
-        }
-      : {
-          ok: false,
-          content: "Failed to Unstar the Package",
-          short: "Server Error",
-        };
+    // If the return does not match our input, it failed.
+    if (user.id != commandUnstar[0].userid || pointer != commandUnstar[0].package) {
+      return {
+        ok: false,
+        content: "Failed to Unstar the Package",
+        short: "Server Error",
+      };
+    }
+
+    return {
+      ok: true,
+      content: "Successfully Unstarred",
+    };
   } catch (err) {
     return { ok: false, content: err, short: "Server Error" };
   }

--- a/src/database.js
+++ b/src/database.js
@@ -85,7 +85,8 @@ async function insertNewPackage(pack) {
         metadata: pack.metadata,
       };
       const packageType =
-        (typeof pack.metadata.themes === "string" && pack.metadata.themes.match(/^themes|ui$/i) !== null)
+        typeof pack.metadata.themes === "string" &&
+        pack.metadata.themes.match(/^themes|ui$/i) !== null
           ? "theme"
           : "package";
 
@@ -1138,7 +1139,10 @@ async function updateIncrementStar(user, pack) {
 
       // Now we expect to get our data right back, and can check the
       // validity to know if this happened successfully or not.
-      if (pointer != commandStar[0].package || user.id != commandStar[0].userid) {
+      if (
+        pointer != commandStar[0].package ||
+        user.id != commandStar[0].userid
+      ) {
         return {
           ok: false,
           content: `Failed to Star the Package`,
@@ -1211,7 +1215,10 @@ async function updateDecrementStar(user, pack) {
     }
 
     // If the return does not match our input, it failed.
-    if (user.id != commandUnstar[0].userid || pointer != commandUnstar[0].package) {
+    if (
+      user.id != commandUnstar[0].userid ||
+      pointer != commandUnstar[0].package
+    ) {
       return {
         ok: false,
         content: "Failed to Unstar the Package",
@@ -1256,9 +1263,10 @@ async function getStarredPointersByUserID(userid) {
     // It is likely safe to assume that if nothing matches the userid,
     // then the user hasn't given any star. So instead of server error
     // here we will non-traditionally return an empty array.
-    const packArray = (command.count !== 0 && Array.isArray(command[0].array))
-      ? command[0].array
-      : [];
+    const packArray =
+      command.count !== 0 && Array.isArray(command[0].array)
+        ? command[0].array
+        : [];
 
     return { ok: true, content: packArray };
   } catch (err) {

--- a/src/database.js
+++ b/src/database.js
@@ -86,7 +86,7 @@ async function insertNewPackage(pack) {
       };
       const packageType =
         typeof pack.metadata.themes === "string" &&
-        pack.metadata.themes.match(/^themes|ui$/i) !== null
+        pack.metadata.themes.match(/^(?:themes|ui)$/i) !== null
           ? "theme"
           : "package";
 
@@ -597,7 +597,7 @@ async function updatePackageStargazers(name, pointer = null) {
     sqlStorage ??= setupSQL();
 
     if (pointer == null) {
-      packID = await getPackageByNameSimple(name);
+      const packID = await getPackageByNameSimple(name);
 
       if (!packID.ok) {
         return packID;

--- a/src/database.js
+++ b/src/database.js
@@ -85,8 +85,7 @@ async function insertNewPackage(pack) {
         metadata: pack.metadata,
       };
       const packageType =
-        pack.metadata.themes !== null &&
-        (pack.metadata.themes == "themes" || pack.metadata.themes == "ui")
+        (typeof pack.metadata.themes === "string" && pack.metadata.themes.match(/^themes|ui$/i) !== null)
           ? "theme"
           : "package";
 

--- a/src/database.js
+++ b/src/database.js
@@ -1087,7 +1087,7 @@ async function updateIncrementStar(user, pack) {
       if (pointer != commandStar[0].package || user.id != commandStar[0].userid) {
         return {
           ok: false,
-          content: `Failed to Star ${pointer} with ${user.id}`,
+          content: `Failed to Star the Package`,
           short: "Server Error",
         };
       }
@@ -1170,11 +1170,11 @@ async function updateDecrementStar(user, pack) {
       pointer == commandUnstar[0].package
       ? {
           ok: true,
-          content: `Successfully Unstarred ${pointer} with ${user.id}`,
+          content: "Successfully Unstarred",
         }
       : {
           ok: false,
-          content: `Failed to Unstar ${pointer} with ${user.id}`,
+          content: "Failed to Unstar the Package",
           short: "Server Error",
         };
   } catch (err) {

--- a/src/database.js
+++ b/src/database.js
@@ -129,15 +129,9 @@ async function insertNewPackage(pack) {
         // therefore set it as NONE if undefined.
         const license = pv[ver].license ?? "NONE";
 
-        // Save version object into meta, but strip engines and license properties
-        // since we save them into specific separate columns.
-        let meta = pv[ver];
-        delete meta.engines;
-        delete meta.license;
-
         command = await sqlTrans`
         INSERT INTO versions (package, status, semver, license, engine, meta)
-        VALUES (${pointer}, ${status}, ${ver}, ${license}, ${engine}, ${meta})
+        VALUES (${pointer}, ${status}, ${ver}, ${license}, ${engine}, ${pv[ver]})
         RETURNING id;
       `;
 

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -35,6 +35,19 @@ ALTER TABLE packages
 ALTER COLUMN package_type TYPE packageType USING (package_type::packageType),
 ALTER COLUMN package_type SET NOT NULL;
 
+CREATE FUNCTION now_on_updated_package()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER trigger_now_on_updated
+    BEFORE UPDATE ON packages
+    FOR EACH ROW
+EXECUTE PROCEDURE now_on_updated_package();
+
 -- Create names Table
 
 CREATE TABLE names (

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -94,31 +94,31 @@ ALTER TABLE versions ADD COLUMN semver_v3 INTEGER
 
 INSERT INTO packages (pointer, package_type, name, creation_method, downloads, stargazers_count, data, original_stargazers)
 VALUES (
-  'd28c7ce5-c9c4-4fb6-a499-a7c6dcec355b', 'package', 'language-css', 'user made', 400004, 76,
+  'd28c7ce5-c9c4-4fb6-a499-a7c6dcec355b', 'package', 'language-css', 'user made', 400004, 1,
   '{"name": "language-css", "readme": "Cool readme", "metadata": {"bugs": {"url": "https://github.com/atom/language-css/issues"},
   "name": "language-css", "engines": {"atom": "*","node":"*"},"license":"MIT","version":"0.45.7","homepage":"http://atom.github.io/language-css",
   "keywords":["tree-sitter"],"repository":{"url":"https://github.com/atom/language-css.git","type":"git"},"description":"CSS Support in Atom",
   "dependencies":{"tree-sitter-css":"^0.19.0"},"devDependencies":{"coffeelint":"^1.10.1"}},"repository":{"url":"https://github.com/atom/langauge-css",
   "type":"git"}}', 76
 ), (
-  'd27dbd37-e58e-4e02-b804-9e3e6ae02fb1', 'package', 'language-cpp', 'user made', 849156, 91,
+  'd27dbd37-e58e-4e02-b804-9e3e6ae02fb1', 'package', 'language-cpp', 'user made', 849156, 1,
   '{"name": "language-cpp", "description": "C++ Support in Atom", "keywords": ["tree-sitter"]}', 91
 ), (
-  'ee87223f-65ab-4a1d-8f45-09fcf8e64423', 'package', 'hydrogen', 'Migrated from Atom.io', 2562844, 821,
+  'ee87223f-65ab-4a1d-8f45-09fcf8e64423', 'package', 'hydrogen', 'Migrated from Atom.io', 2562844, 1,
   '{"name": "hydrogen", "readme": "Hydrogen Readme", "metadata": { "main": "./dist/main", "name": "Hydrogen",
   "author": "nteract contributors", "engines": {"atom": ">=1.28.0 <2.0.0"}, "license": "MIT", "version": "2.16.3"}}', 821
 ), (
-  'aea26882-8459-4725-82ad-41bf7aa608c3', 'package', 'atom-clock', 'Migrated from Atom.io', 1090899, 528,
+  'aea26882-8459-4725-82ad-41bf7aa608c3', 'package', 'atom-clock', 'Migrated from Atom.io', 1090899, 1,
   '{"name": "atom-clock", "readme": "Atom-clok!", "metadata": { "main": "./lib/atom-clock", "name": "atom-clock",
   "author": { "url": "https://github.com/b3by", "name": "Antonio Bevilacqua", "email": "b3by.in.the3.sky@gmail.com"}}}', 528
 ), (
-  '1e19da12-322a-4b37-99ff-64f866cc0cfa', 'package', 'hey-pane', 'Migrated from Atom.io', 206804, 176,
+  '1e19da12-322a-4b37-99ff-64f866cc0cfa', 'package', 'hey-pane', 'Migrated from Atom.io', 206804, 1,
   '{"name": "hey-pane", "readme": "hey-pane!", "metadata": { "main": "./lib/hey-pane", "license": "MIT"}}', 176
 ), (
-  'a0ef01cb-720e-4c0d-80c5-f0ed441f31fc', 'theme', 'atom-material-ui', 'Migrated from Atom.io', 2509605, 1772,
+  'a0ef01cb-720e-4c0d-80c5-f0ed441f31fc', 'theme', 'atom-material-ui', 'Migrated from Atom.io', 2509605, 1,
   '{"name": "atom-material-ui", "readme": "ATOM!"}', 1772
 ), (
-  '28952de5-ddbf-41a8-8d87-5d7e9d7ad7ac', 'theme', 'atom-material-syntax', 'Migrated from Atom.io', 1743927, 1309,
+  '28952de5-ddbf-41a8-8d87-5d7e9d7ad7ac', 'theme', 'atom-material-syntax', 'Migrated from Atom.io', 1743927, 1,
   '{"name": "atom-material-syntax"}', 1309
 );
 

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -579,6 +579,16 @@ async function postPackagesVersion(req, res) {
     packageName: query.packageName(req),
   };
 
+  /* Check tag validity
+  if (params.tag === "") {
+    await common.handleError(req, res, {
+      ok: false,
+      short: "Bad Repo",
+      content: "The tag parameter is not correctly specified",
+    });
+    return;
+  }*/
+
   // On renaming:
   // When a package is being renamed, we will expect that packageName will
   // match a previously published package.
@@ -643,7 +653,8 @@ async function postPackagesVersion(req, res) {
   // Now the only thing left to do, is add this new version with the name from the package.
   // And check again if the name is incorrect, since it'll need a new entry onto the names.
 
-  if (packJSON.name !== params.packageName && params.rename) {
+  const rename = packJSON.name !== params.packageName && params.rename;
+  if (rename) {
     // Before allowing the rename of a package, ensure the new name isn't banned.
 
     const isBanned = await utils.isPackageNameBanned(packJSON.name);
@@ -659,22 +670,14 @@ async function postPackagesVersion(req, res) {
       // TODO ^^^ Replace with specific error once more are supported.
       return;
     }
-
-    // The flow for renaming the existing package.
-    const newName = await database.insertNewPackageName(
-      packJSON.name,
-      params.packageName
-    );
-
-    if (!newName.ok) {
-      await common.handleError(req, res, newName);
-      return;
-    }
   }
 
   // Now add the new Version key.
 
-  const addVer = await database.insertNewPackageVersion(packJSON);
+  const addVer = await database.insertNewPackageVersion(
+    packJSON,
+    rename ? params.packageName : null
+  );
 
   if (!addVer.ok) {
     await common.handleError(req, res, addVer);

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -460,19 +460,6 @@ async function postPackagesStar(req, res) {
     return;
   }
 
-  const exists = await database.getPackageByName(params.packageName, true);
-
-  if (!exists.ok) {
-    // The package we are trying to star doesn't exist, resolve with a 404.
-    await common.handleError(
-      req,
-      res,
-      { ok: false, short: "Not Found", content: exists.content },
-      1012
-    );
-    return;
-  }
-
   const star = await database.updateStars(user.content, params.packageName);
 
   if (!star.ok) {

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -460,7 +460,7 @@ async function postPackagesStar(req, res) {
     return;
   }
 
-  const star = await database.updateStars(user.content, params.packageName);
+  const star = await database.updateIncrementStar(user.content, params.packageName);
 
   if (!star.ok) {
     await common.handleError(req, res, user, 1009);
@@ -512,7 +512,7 @@ async function deletePackagesStar(req, res) {
     return;
   }
 
-  const unstar = await database.updateDeleteStar(
+  const unstar = await database.updateDecrementStar(
     user.content,
     params.packageName
   );

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -460,19 +460,13 @@ async function postPackagesStar(req, res) {
     return;
   }
 
-  const star = await database.updateIncrementStar(user.content, params.packageName);
-
-  if (!star.ok) {
-    await common.handleError(req, res, user, 1009);
-    return;
-  }
-
-  const updatePack = await database.updatePackageIncrementStarByName(
+  const star = await database.updateIncrementStar(
+    user.content,
     params.packageName
   );
 
-  if (!updatePack.ok) {
-    await common.handleError(req, res, updatePack, 1010);
+  if (!star.ok) {
+    await common.handleError(req, res, star, 1009);
     return;
   }
 
@@ -519,15 +513,6 @@ async function deletePackagesStar(req, res) {
 
   if (!unstar.ok) {
     await common.handleError(req, res, unstar);
-    return;
-  }
-
-  const updatePack = await database.updatePackageDecrementStarByName(
-    params.packageName
-  );
-
-  if (!updatePack.ok) {
-    await common.handleError(req, res, updatePack);
     return;
   }
 

--- a/src/query.js
+++ b/src/query.js
@@ -9,18 +9,24 @@
  * @function page
  * @desc Parser of the Page query parameter. Defaulting to 1.
  * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @returns {string} Returns the valid page provided in the query parameter or 1, as the default.
+ * @returns {number} Returns the valid page provided in the query parameter or 1, as the default.
  */
 function page(req) {
   const def = 1;
   const prov = req.query.page;
 
-  if (prov === undefined) {
-    return def;
-  }
+  switch (typeof prov) {
+    case "string": {
+      const n = parseInt(prov, 10);
+      return isNaN(prov) ? def : n;
+    }
 
-  // ensure it's a proper number
-  return prov.match(/^\d+$/) !== null ? prov : def;
+    case "number":
+      return isNaN(prov) ? def : prov;
+
+    default:
+      return def;
+  }
 }
 
 /**

--- a/src/query.js
+++ b/src/query.js
@@ -150,7 +150,7 @@ function repo(req) {
  * @returns {string} Returns a valid 'tag' query parameter. Or '' if invalid.
  */
 function tag(req) {
-  return req.query.tag ?? "";
+  return typeof req.query.tag !== "string" ? "" : req.query.tag;
 }
 
 /**

--- a/src/tests/query.test.js
+++ b/src/tests/query.test.js
@@ -3,9 +3,9 @@ const query = require("../query.js");
 // Page Testing
 
 const page_cases = [
-  [{ query: { page: "3" } }, "3"],
+  [{ query: { page: "3" } }, 3],
   [{ query: {} }, 1],
-  [{ query: { page: "2" } }, "2"],
+  [{ query: { page: "2" } }, 2],
   [{ query: { page: "JustText" } }, 1],
   [{ query: { page: undefined } }, 1],
 ];

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -436,8 +436,16 @@ describe("Package Lifecycle Tests", () => {
       getUserID.content,
       "language-css"
     );
-    //expect(starPack.ok).toBeTruthy();
+    expect(starPack.ok).toBeTruthy();
     expect(starPack.content).toEqual("Package Successfully Starred");
+
+    // === Can we add a new star to the same package with our User?
+    const reStarPack = await database.updateIncrementStar(
+      getUserID.content,
+      "language-css"
+    );
+    expect(reStarPack.ok).toBeTruthy();
+    expect(reStarPack.content).toEqual("Package Already Starred");
 
     // === Does our user now have valid stars?
     const getStars = await database.getStarredPointersByUserID(USER_ID);
@@ -451,6 +459,19 @@ describe("Package Lifecycle Tests", () => {
     );
     expect(remStar.ok).toBeTruthy();
     expect(remStar.content).toEqual("Package Successfully Unstarred");
+
+    // === What happens if the User try to remove a star from un unstarred package?
+    const reRemStar = await database.updateDecrementStar(
+      getUserID.content,
+      "language-css"
+    );
+    expect(reRemStar.ok).toBeTruthy();
+    expect(reRemStar.content).toEqual("The Star is Already Missing");
+
+    // === Does our user now have valid stars?
+    const getNoStars = await database.getStarredPointersByUserID(USER_ID);
+    expect(getNoStars.ok).toBeTruthy();
+    expect(getNoStars.content.length).toEqual(0);
 
     // === Can we remove our User?
     // TODO: Currently there is no way to delete a user account.

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -462,13 +462,12 @@ describe("Package Lifecycle Tests", () => {
     expect(getFakeStars.content.length).toEqual(0);
 
     // === Can we star a package with our User?
-    const starPack = await database.updateStars(
+    const starPack = await database.updateIncrementStar(
       getUserID.content,
       "language-css"
     );
     expect(starPack.ok).toBeTruthy();
-    expect(starPack.content.startsWith("Successfully Stared ")).toBeTruthy();
-    expect(starPack.content.endsWith(` with ${USER_ID}`)).toBeTruthy();
+    expect(starPack.content).toEqual("Package Successfully Starred");
 
     // === Does our user now have valid stars?
     const getStars = await database.getStarredPointersByUserID(USER_ID);
@@ -476,7 +475,7 @@ describe("Package Lifecycle Tests", () => {
     expect(getStars.content.length).toEqual(1);
 
     // === Can we remove our star?
-    const remStar = await database.updateDeleteStar(
+    const remStar = await database.updateDecrementStar(
       getUserID.content,
       "language-css"
     );

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -278,36 +278,6 @@ describe("Package Lifecycle Tests", () => {
     expect(downPackReUndo.content.name).toEqual(NEW_NAME);
     expect(downPackReUndo.content.downloads).toEqual("0");
 
-    // === Can we star our package?
-    const starPack = await database.updatePackageIncrementStarByName(NEW_NAME);
-    expect(starPack.ok).toBeTruthy();
-    expect(starPack.content.name).toEqual(NEW_NAME);
-    expect(starPack.content.stargazers_count).toEqual("1");
-
-    // === Can we unstar our package?
-    const starPackUndo = await database.updatePackageDecrementStarByName(
-      NEW_NAME
-    );
-    expect(starPackUndo.ok).toBeTruthy();
-    expect(starPackUndo.content.name).toEqual(NEW_NAME);
-    expect(starPackUndo.content.stargazers_count).toEqual("0");
-
-    // === Can we get the stars of our package below zero?
-    const starPackReUndo = await database.updatePackageDecrementStarByName(
-      NEW_NAME
-    );
-    expect(starPackReUndo.ok).toBeTruthy();
-    expect(starPackReUndo.content.name).toEqual(NEW_NAME);
-    expect(starPackReUndo.content.stargazers_count).toEqual("0");
-
-    // === Can we star by the old name?
-    const starPackOld = await database.updatePackageIncrementStarByName(
-      pack.createPack.name
-    );
-    expect(starPackOld.ok).toBeTruthy();
-    expect(starPackOld.content.name).toEqual(NEW_NAME);
-    expect(starPackOld.content.stargazers_count).toEqual("1");
-
     // === Can we download by old name?
     const downPackOld = await database.updatePackageIncrementDownloadByName(
       pack.createPack.name
@@ -466,7 +436,7 @@ describe("Package Lifecycle Tests", () => {
       getUserID.content,
       "language-css"
     );
-    expect(starPack.ok).toBeTruthy();
+    //expect(starPack.ok).toBeTruthy();
     expect(starPack.content).toEqual("Package Successfully Starred");
 
     // === Does our user now have valid stars?

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -480,8 +480,7 @@ describe("Package Lifecycle Tests", () => {
       "language-css"
     );
     expect(remStar.ok).toBeTruthy();
-    expect(remStar.content.startsWith("Successfully Unstarred ")).toBeTruthy();
-    expect(remStar.content.endsWith(` with ${USER_ID}`)).toBeTruthy();
+    expect(remStar.content).toEqual("Successfully Unstarred");
 
     // === Can we remove our User?
     // TODO: Currently there is no way to delete a user account.

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -480,7 +480,7 @@ describe("Package Lifecycle Tests", () => {
       "language-css"
     );
     expect(remStar.ok).toBeTruthy();
-    expect(remStar.content).toEqual("Successfully Unstarred");
+    expect(remStar.content).toEqual("Package Successfully Unstarred");
 
     // === Can we remove our User?
     // TODO: Currently there is no way to delete a user account.

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -476,9 +476,9 @@ describe("POST /api/packages/:packageName/star", () => {
     expect(res).toHaveHTTPCode(200);
     // DESCRIBE: Returns same Package
     expect(res.body.name).toEqual("language-css");
-    // DESCRIBE: Properly Decreases Star Count
-    expect(parseInt(res.body.stargazers_count, 10)).toBeGreaterThan(
-      parseInt(prev.body.stargazers_count, 10)
+    // DESCRIBE: Properly Increases Star Count
+    expect(parseInt(res.body.stargazers_count, 10)).toEqual(
+      parseInt(prev.body.stargazers_count, 10) + 1
     );
     // DESCRIBE: A duplicate Request Returns Success Status Code
     expect(dup).toHaveHTTPCode(200);

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -469,9 +469,8 @@ describe("POST /api/packages/:packageName/star", () => {
     const dup = await request(app)
       .post("/api/packages/language-css/star")
       .set("Authorization", "valid-token");
-    // We are preforming multiple checks in the single check, because, as expected trying to star a package
-    // that you have already stared errors out.
-    // Unfortunately we can't nest another describe into the test, so we will use comments to make things clear.
+    // We are preforming multiple checks in the single check,
+    // because we want to test a star action when the package is already starred.
 
     // DESCRIBE: Returns Success Status Code
     expect(res).toHaveHTTPCode(200);
@@ -481,10 +480,12 @@ describe("POST /api/packages/:packageName/star", () => {
     expect(parseInt(res.body.stargazers_count, 10)).toBeGreaterThan(
       parseInt(prev.body.stargazers_count, 10)
     );
-    // DESCRIBE: A duplicate Request Returns Error Status
-    expect(dup).toHaveHTTPCode(500);
-    // DESCRIBE: A duplicate Request Returns Error Message
-    expect(dup.body.message).toEqual(msg.serverError);
+    // DESCRIBE: A duplicate Request Returns Success Status Code
+    expect(dup).toHaveHTTPCode(200);
+    // DESCRIBE: A duplicate Request keeps the star, but does not increase the count
+    expect(parseInt(res.body.stargazers_count, 10)).toEqual(
+      parseInt(dup.body.stargazers_count, 10)
+    );
   });
 });
 
@@ -521,16 +522,16 @@ describe("DELETE /api/packages/:packageName/star", () => {
       .set("Authorization", "valid-token");
     expect(res.body.message).toEqual(msg.notFound);
   });
-  test("Returns Not Found when not a starred package", async () => {
-    const res = await request(app)
-      .delete("/api/packages/language-css/star")
-      .set("Authorization", "no-star-token");
-    expect(res).toHaveHTTPCode(404);
-  });
   test("Returns 201 on Success", async () => {
     const res = await request(app)
       .delete("/api/packages/language-css/star")
       .set("Authorization", "all-star-token");
+    expect(res).toHaveHTTPCode(201);
+  });
+  test("Returns 201 even when the package is not starred", async () => {
+    const res = await request(app)
+      .delete("/api/packages/language-css/star")
+      .set("Authorization", "no-star-token");
     expect(res).toHaveHTTPCode(201);
   });
 });


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

This introduces a new stargazers management.
- The star given by the user is added in star table and then the star count of the package is updated with SQL COUNT. I know we wanted to avoid this, but we use PostgreSQL which is pretty good on performance, so I'd say let's the use recount on every star given/removed. If there are performance issue, we will try a light way.
- This is also good since we have a way to update the real count. In case a user will be deleted, the count is updated when a star is given/removed to the real number and not the previous one that was still counting the removed user.

This changes the response when a star is given or removed multiple times.
- Because the endpoint is used to say that the star of the user is appointed, we return 201 even on multiple requests. Obviously the count in not incremented because the primary key constraint is violated. 
- When the star is removed multiple times, we inform that the star is not present while the count is unchanged.
- @confused-Techie If you don't agree with this, it can be easily changed.

Added the points in #111 
- @confused-Techie before testing, please take a look at the changes in the packages SQL script.
- The main change is the integration of the renaming in the insertNewPackageVersion transaction. This way the new name is not registered in case the new version insertion fails.
- This should be tested on the endpoint anyway. For the moment I left insertNewPackageName for testing purpose.

Fixes #110 
Fixes #111 

@confused-Techie for any question before the merge, ask here.